### PR TITLE
Reworking the Writer constructor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,7 @@ func main() {
 	
 	// Create a wave.Writer that wraps 'f'
     w, _ := wave.NewWriter(
-        wave.WithBaseWriter(f),
-        wave.WithChannelCount(uint16(1)),
-        wave.WithSampleRate(uint32(44100)),
-        wave.WithSampleType(wave.SampleTypeInt16),
+		f, wave.SampleTypeInt16, uint32(44100), wave.WithChannelCount(2),
     )
 	defer func() {
 		_ = w.Flush()
@@ -58,12 +55,14 @@ func main() {
 }
 ```
 
-`wave.NewWriter` provides functional arguments that allow the caller to set the 
-number of channels, the sample rate, and the expected data type for the audio
-samples. `wave.Writer` supports the `uint8`, `int16`, `int24`, and `int32` PCM 
-formats as well as the `float32` and `float64` IEEE formats. The base writer,
-sample rate, and sample type are all required, but the channel count will be
-default to 1 if not otherwise specified.
+`wave.NewWriter` requires that the caller provide a base writer, the expected
+data type for the audio samples, and the sample rate. `wave.Writer` supports 
+the `uint8`, `int16`, `int24`, and `int32` PCM formats as well as the `float32` 
+and `float64` IEEE formats. 
+
+Other optional writer properties can be set via functional arguments. In the 
+example above, the channel count has been set, overriding the default value 
+of 1.
 
 ### Working with multiple channels
 The API assumes that all samples are *interleaved* (as opposed to *strided*),

--- a/examples/stream-writer/main.go
+++ b/examples/stream-writer/main.go
@@ -30,10 +30,7 @@ func main() {
 
 	// 2. Create a wave writer and set the properties we care about
 	w, err := wave.NewWriter(
-		wave.WithBaseWriter(f),
-		wave.WithChannelCount(uint16(1)),
-		wave.WithSampleRate(uint32(sampleRate)),
-		wave.WithSampleType(wave.SampleTypeInt24),
+		f, wave.SampleTypeInt24, uint32(sampleRate),
 	)
 	if err != nil {
 		failF(err)

--- a/examples/wave-writer/main.go
+++ b/examples/wave-writer/main.go
@@ -68,10 +68,7 @@ func saveAsWave(
 
 	// Create a writer and set the properties we care about
 	w, err := wave.NewWriter(
-		wave.WithBaseWriter(out),
-		wave.WithChannelCount(uint16(channelCount)),
-		wave.WithSampleRate(uint32(sampleRate)),
-		wave.WithSampleType(format),
+		out, format, uint32(sampleRate), wave.WithChannelCount(uint16(channelCount)),
 	)
 	if err != nil {
 		return err

--- a/wave/e2e_test.go
+++ b/wave/e2e_test.go
@@ -22,10 +22,7 @@ func TestE2E_Empty(t *testing.T) {
 
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeUint8),
-		WithChannelCount(2),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeUint8, 44100, WithChannelCount(2),
 	)
 	require.NoError(t, err)
 
@@ -65,10 +62,7 @@ func TestE2E_Uint8_Normal(t *testing.T) {
 
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeUint8),
-		WithChannelCount(2),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeUint8, 44100, WithChannelCount(2),
 	)
 	require.NoError(t, err)
 
@@ -107,10 +101,7 @@ func TestE2E_Uint8_Padding(t *testing.T) {
 
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeUint8),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeUint8, 44100,
 	)
 	require.NoError(t, err)
 
@@ -149,10 +140,7 @@ func TestE2E_Uint8_Padding(t *testing.T) {
 func TestE2E_Uint8_Extensible(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeUint8),
-		WithChannelCount(4),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeUint8, 44100, WithChannelCount(4),
 	)
 	require.NoError(t, err)
 
@@ -206,10 +194,7 @@ func TestE2E_Uint8_Extensible(t *testing.T) {
 func TestE2E_Int16_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeInt16),
-		WithChannelCount(2),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeInt16, 44100, WithChannelCount(2),
 	)
 	require.NoError(t, err)
 
@@ -247,10 +232,7 @@ func TestE2E_Int16_Normal(t *testing.T) {
 func TestE2E_Int16_Extensible(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeInt16),
-		WithChannelCount(4),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeInt16, 44100, WithChannelCount(4),
 	)
 	require.NoError(t, err)
 
@@ -312,10 +294,7 @@ func TestE2E_Int24_Normal(t *testing.T) {
 
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeInt24),
-		WithChannelCount(2),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeInt24, 44100, WithChannelCount(2),
 	)
 	require.NoError(t, err)
 
@@ -372,10 +351,7 @@ func TestE2E_Int24_Padding(t *testing.T) {
 
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeInt24),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeInt24, 44100,
 	)
 	require.NoError(t, err)
 
@@ -432,10 +408,7 @@ func TestE2E_Int24_Padding(t *testing.T) {
 func TestE2E_Int32_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeInt32),
-		WithChannelCount(2),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeInt32, 44100, WithChannelCount(2),
 	)
 	require.NoError(t, err)
 
@@ -496,10 +469,7 @@ func TestE2E_Int32_Normal(t *testing.T) {
 func TestE2E_Float32_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeFloat32),
-		WithChannelCount(2),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeFloat32, 44100, WithChannelCount(2),
 	)
 	require.NoError(t, err)
 
@@ -544,10 +514,7 @@ func TestE2E_Float32_Extensible(t *testing.T) {
 
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeFloat32),
-		WithChannelCount(4),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeFloat32, 44100, WithChannelCount(4),
 	)
 	require.NoError(t, err)
 
@@ -609,10 +576,7 @@ func TestE2E_Float64_Normal(t *testing.T) {
 
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeFloat64),
-		WithChannelCount(2),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeFloat64, 44100, WithChannelCount(2),
 	)
 	require.NoError(t, err)
 
@@ -657,10 +621,7 @@ func TestE2E_Float64_Extensible(t *testing.T) {
 
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeFloat64),
-		WithChannelCount(4),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeFloat64, 44100, WithChannelCount(4),
 	)
 	require.NoError(t, err)
 

--- a/wave/wave.go
+++ b/wave/wave.go
@@ -1,5 +1,5 @@
 // Package wave contains types and functions that facilitate working with
-// .wave files.
+// Wave (.wav) files.
 package wave
 
 // References

--- a/wave/writer_test.go
+++ b/wave/writer_test.go
@@ -14,10 +14,7 @@ import (
 func TestNewWriter_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeUint8),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeUint8, 44100,
 	)
 	require.NoError(t, err)
 
@@ -33,10 +30,7 @@ func TestNewWriter_Normal(t *testing.T) {
 func TestNewWriter_WithFactChunk(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeFloat32),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeFloat32, 44100,
 	)
 	require.NoError(t, err)
 
@@ -52,37 +46,11 @@ func TestNewWriter_WithFactChunk(t *testing.T) {
 
 func TestNewWriter_Errors(t *testing.T) {
 
-	// Missing sample type
 	baseWriter := &bytes.Writer{}
-	_, err := NewWriter(
-		WithSampleRate(44100),
-		WithChannelCount(2),
-		WithBaseWriter(baseWriter),
-	)
-	require.ErrorIs(t, err, ErrWriterMissingSampleType)
-
-	// Missing sample rate
-	_, err = NewWriter(
-		WithSampleType(SampleTypeUint8),
-		WithChannelCount(2),
-		WithBaseWriter(baseWriter),
-	)
-	require.ErrorIs(t, err, ErrWriterMissingSampleRate)
-
-	// Missing base writer
-	_, err = NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleTypeUint8),
-		WithChannelCount(2),
-	)
-	require.ErrorIs(t, err, ErrWriterMissingBaseWriter)
 
 	// Invalid option (e.g. bad sample type)
-	_, err = NewWriter(
-		WithSampleRate(44100),
-		WithSampleType(SampleType(-1)),
-		WithChannelCount(2),
-		WithBaseWriter(baseWriter),
+	_, err := NewWriter(
+		baseWriter, SampleType(-1), 44100,
 	)
 	require.ErrorIs(t, err, ErrWriterInvalidSampleType)
 }
@@ -94,10 +62,7 @@ func TestNewWriter_Errors(t *testing.T) {
 func TestWriter_Flush_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeFloat32),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeFloat32, 44100,
 	)
 	require.NoError(t, err)
 
@@ -112,10 +77,7 @@ func TestWriter_Flush_Normal(t *testing.T) {
 func TestWriter_Flush_NoData(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeUint8),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeUint8, 44100,
 	)
 	require.NoError(t, err)
 
@@ -127,10 +89,7 @@ func TestWriter_Flush_NoData(t *testing.T) {
 func TestWriter_Flush_WithPadding(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeUint8),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeUint8, 44100,
 	)
 	require.NoError(t, err)
 
@@ -145,10 +104,8 @@ func TestWriter_Flush_WithPadding(t *testing.T) {
 func TestWriter_Flush_InvalidByteCount(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeUint8),
-		WithSampleRate(44100),
+		baseWriter, SampleTypeUint8, 44100,
 		WithChannelCount(2),
-		WithBaseWriter(baseWriter),
 	)
 	require.NoError(t, err)
 
@@ -167,10 +124,7 @@ func TestWriter_Flush_InvalidByteCount(t *testing.T) {
 func TestWriter_WriteInterleavedUint8_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeUint8),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeUint8, 44100,
 	)
 	require.NoError(t, err)
 
@@ -182,10 +136,7 @@ func TestWriter_WriteInterleavedUint8_Normal(t *testing.T) {
 func TestWriter_WriteInterleavedUint8_InvalidSampleType(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeFloat32),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeFloat32, 44100,
 	)
 	require.NoError(t, err)
 
@@ -200,10 +151,7 @@ func TestWriter_WriteInterleavedUint8_InvalidSampleType(t *testing.T) {
 func TestWriter_WriteInterleavedInt16_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeInt16),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeInt16, 44100,
 	)
 	require.NoError(t, err)
 
@@ -215,10 +163,7 @@ func TestWriter_WriteInterleavedInt16_Normal(t *testing.T) {
 func TestWriter_WriteInterleavedInt16_InvalidSampleType(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeFloat32),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeFloat32, 44100,
 	)
 	require.NoError(t, err)
 
@@ -233,10 +178,7 @@ func TestWriter_WriteInterleavedInt16_InvalidSampleType(t *testing.T) {
 func TestWriter_WriteInterleavedInt24_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeInt24),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeInt24, 44100,
 	)
 	require.NoError(t, err)
 
@@ -248,10 +190,7 @@ func TestWriter_WriteInterleavedInt24_Normal(t *testing.T) {
 func TestWriter_WriteInterleavedInt24_InvalidSampleType(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeFloat32),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeFloat32, 44100,
 	)
 	require.NoError(t, err)
 
@@ -266,10 +205,7 @@ func TestWriter_WriteInterleavedInt24_InvalidSampleType(t *testing.T) {
 func TestWriter_WriteInterleavedInt32_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeInt32),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeInt32, 44100,
 	)
 	require.NoError(t, err)
 
@@ -281,10 +217,7 @@ func TestWriter_WriteInterleavedInt32_Normal(t *testing.T) {
 func TestWriter_WriteInterleavedInt32_InvalidSampleType(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeFloat32),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeFloat32, 44100,
 	)
 	require.NoError(t, err)
 
@@ -299,10 +232,7 @@ func TestWriter_WriteInterleavedInt32_InvalidSampleType(t *testing.T) {
 func TestWriter_WriteInterleavedFloat32_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeFloat32),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeFloat32, 44100,
 	)
 	require.NoError(t, err)
 
@@ -314,10 +244,7 @@ func TestWriter_WriteInterleavedFloat32_Normal(t *testing.T) {
 func TestWriter_WriteInterleavedFloat32_InvalidSampleType(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeUint8),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeUint8, 44100,
 	)
 	require.NoError(t, err)
 
@@ -332,10 +259,7 @@ func TestWriter_WriteInterleavedFloat32_InvalidSampleType(t *testing.T) {
 func TestWriter_WriteInterleavedFloat64_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeFloat64),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeFloat64, 44100,
 	)
 	require.NoError(t, err)
 
@@ -347,10 +271,7 @@ func TestWriter_WriteInterleavedFloat64_Normal(t *testing.T) {
 func TestWriter_WriteInterleavedFloat64_InvalidSampleType(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
-		WithSampleType(SampleTypeUint8),
-		WithSampleRate(44100),
-		WithChannelCount(1),
-		WithBaseWriter(baseWriter),
+		baseWriter, SampleTypeUint8, 44100,
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
**Changelog**:
  - `wave.Writer` was abusing the functional arguments pattern a bit because some of the arguments are actually required. With this PR, the required arguments are changed to be normal function arguments. Optional arguments are left as functional arguments for now.
  - Updated examples and documentation to reflect the API changes.