### PR TITLE
Clarified multi-channel block layout

### DIFF
--- a/examples/stream-writer/main.go
+++ b/examples/stream-writer/main.go
@@ -28,7 +28,9 @@ func main() {
 		_ = f.Close()
 	}()
 
-	// 2. Create a wave writer and set the properties we care about
+	// 2. Create a wave writer and set the properties we care about. In this
+	// example, we'll write our resulting .wav file to 'f' using 24-bit PCM
+	// data.
 	w, err := wave.NewWriter(
 		f, wave.SampleTypeInt24, uint32(sampleRate),
 	)
@@ -43,17 +45,17 @@ func main() {
 	}()
 
 	// 3. We'll use a channel to facilitate communication between a background
-	// goroutine (responsible for generating blocks of audio data) and the
-	// main goroutine (responsible for transforming those blocks and writing
+	// goroutine (responsible for generating buffers of audio data) and the
+	// main goroutine (responsible for transforming those buffers and writing
 	// them to disk).
 	//
-	// Note that individual audio blocks (not the entire audio file) are kept
+	// Note that individual audio buffers (not the entire audio file) are kept
 	// in memory. As a result, memory usage is not expected to appreciably grow
 	// while we're streaming.
 	c := make(chan []float64)
 	go generateSineWave(c, duration, sampleRate, sineFrequency, sineGain)
-	for block := range c {
-		err = w.WriteInterleavedInt24(core.QuantizeToInt24(block))
+	for buffer := range c {
+		err = w.WriteInt24(core.QuantizeToInt24(buffer))
 		if err != nil {
 			failF(err)
 		}
@@ -69,36 +71,36 @@ func generateSineWave(
 ) {
 
 	const (
-		Tau       = 2 * math.Pi
-		BlockSize = 512
+		Tau        = 2 * math.Pi
+		BufferSize = 512
 	)
 
 	// Work out how many total samples we need based on the duration and the
 	// sample rate.
 	totalSamples := int(duration.Seconds() * float64(sampleRate))
 
-	// We'll divide the samples into blocks to simulate a more real-world
-	// scenario. All blocks but the last will be full sized. The last block
+	// We'll divide the samples into buffers to simulate a more real-world
+	// scenario. All buffers but the last will be full sized. The last buffer
 	// will contain any remaining samples.
-	blockCount := totalSamples / BlockSize
-	lastBlockSamples := totalSamples % BlockSize
+	bufferCount := totalSamples / BufferSize
+	lastBufferSamples := totalSamples % BufferSize
 
 	var x float64
 	samplingInterval := 1.0 / float64(sampleRate)
 
-	// Publish each full sized block to the channel
-	for b := 0; b < blockCount; b++ {
-		buffer := make([]float64, BlockSize)
-		for i := 0; i < BlockSize; i++ {
+	// Publish each full sized buffer to the channel
+	for b := 0; b < bufferCount; b++ {
+		buffer := make([]float64, BufferSize)
+		for i := 0; i < BufferSize; i++ {
 			buffer[i] = gain * math.Sin(Tau*frequency*x)
 			x += samplingInterval
 		}
 		c <- buffer
 	}
 
-	// Publish the last block
-	buffer := make([]float64, lastBlockSamples)
-	for i := 0; i < lastBlockSamples; i++ {
+	// Publish the last buffer
+	buffer := make([]float64, lastBufferSamples)
+	for i := 0; i < lastBufferSamples; i++ {
 		buffer[i] = gain * math.Sin(Tau*frequency*x)
 		x += samplingInterval
 	}

--- a/examples/wave-writer/main.go
+++ b/examples/wave-writer/main.go
@@ -35,7 +35,7 @@ func main() {
 	}()
 
 	// 3. Save the audio data as a wave file
-	err = saveAsWave(f, samples, 1, sampleRate, wave.SampleTypeInt24)
+	err = saveAsWave(samples, f, wave.SampleTypeInt24, sampleRate)
 	if err != nil {
 		failF(err)
 	}
@@ -59,17 +59,14 @@ func generateSineWave(
 }
 
 func saveAsWave(
-	out io.WriteSeeker,
 	data []float64,
-	channelCount int,
-	sampleRate int,
+	out io.WriteSeeker,
 	format wave.SampleType,
+	sampleRate int,
 ) error {
 
 	// Create a writer and set the properties we care about
-	w, err := wave.NewWriter(
-		out, format, uint32(sampleRate), wave.WithChannelCount(uint16(channelCount)),
-	)
+	w, err := wave.NewWriter(out, format, uint32(sampleRate))
 	if err != nil {
 		return err
 	}
@@ -77,17 +74,17 @@ func saveAsWave(
 	// Quantize the audio data and write it to our wave writer
 	switch format {
 	case wave.SampleTypeUint8:
-		err = w.WriteInterleavedUint8(core.QuantizeToUint8(data))
+		err = w.WriteUint8(core.QuantizeToUint8(data))
 	case wave.SampleTypeInt16:
-		err = w.WriteInterleavedInt16(core.QuantizeToInt16(data))
+		err = w.WriteInt16(core.QuantizeToInt16(data))
 	case wave.SampleTypeInt24:
-		err = w.WriteInterleavedInt24(core.QuantizeToInt24(data))
+		err = w.WriteInt24(core.QuantizeToInt24(data))
 	case wave.SampleTypeInt32:
-		err = w.WriteInterleavedInt32(core.QuantizeToInt32(data))
+		err = w.WriteInt32(core.QuantizeToInt32(data))
 	case wave.SampleTypeFloat32:
-		err = w.WriteInterleavedFloat32(core.QuantizeToFloat32(data))
+		err = w.WriteFloat32(core.QuantizeToFloat32(data))
 	default:
-		err = w.WriteInterleavedFloat64(data)
+		err = w.WriteFloat64(data)
 	}
 	if err != nil {
 		return err

--- a/wave/e2e_test.go
+++ b/wave/e2e_test.go
@@ -67,7 +67,7 @@ func TestE2E_Uint8_Normal(t *testing.T) {
 	require.NoError(t, err)
 
 	// Write the file
-	err = w.WriteInterleavedUint8([]uint8{0, 1, 127, 128, 254, 255})
+	err = w.WriteUint8([]uint8{0, 1, 127, 128, 254, 255})
 	require.NoError(t, err)
 	err = w.Flush()
 	require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestE2E_Uint8_Padding(t *testing.T) {
 	require.NoError(t, err)
 
 	// Write the file
-	err = w.WriteInterleavedUint8([]uint8{0, 1, 2})
+	err = w.WriteUint8([]uint8{0, 1, 2})
 	require.NoError(t, err)
 	err = w.Flush()
 	require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestE2E_Uint8_Extensible(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedUint8(
+	err = w.WriteUint8(
 		[]uint8{0, 1, 2, 3, 127, 128, 129, 130, 252, 253, 254, 255},
 	)
 	require.NoError(t, err)
@@ -198,7 +198,7 @@ func TestE2E_Int16_Normal(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedInt16([]int16{-32768, -32767, 0, 1, 32766, 32767})
+	err = w.WriteInt16([]int16{-32768, -32767, 0, 1, 32766, 32767})
 	require.NoError(t, err)
 	err = w.Flush()
 	require.NoError(t, err)
@@ -236,7 +236,7 @@ func TestE2E_Int16_Extensible(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedInt16([]int16{
+	err = w.WriteInt16([]int16{
 		-32768, -32767, -32766, -32765, 0, 1, 2, 3, 32764, 32765, 32766, 32767,
 	})
 	require.NoError(t, err)
@@ -298,7 +298,7 @@ func TestE2E_Int24_Normal(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedInt24([]int32{-8388608, -8388607, 0, 1, 8388606, 8388607})
+	err = w.WriteInt24([]int32{-8388608, -8388607, 0, 1, 8388606, 8388607})
 	require.NoError(t, err)
 	err = w.Flush()
 	require.NoError(t, err)
@@ -355,7 +355,7 @@ func TestE2E_Int24_Padding(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedInt24([]int32{-8388608})
+	err = w.WriteInt24([]int32{-8388608})
 	require.NoError(t, err)
 	err = w.Flush()
 	require.NoError(t, err)
@@ -412,7 +412,7 @@ func TestE2E_Int32_Normal(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedInt32([]int32{
+	err = w.WriteInt32([]int32{
 		-2147483648, -2147483647, 0, 1, 2147483646, 2147483647,
 	})
 	require.NoError(t, err)
@@ -473,7 +473,7 @@ func TestE2E_Float32_Normal(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedFloat32([]float32{
+	err = w.WriteFloat32([]float32{
 		-1.0, -0.99, 0, 0.1, 0.99, 1.0,
 	})
 	require.NoError(t, err)
@@ -518,7 +518,7 @@ func TestE2E_Float32_Extensible(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedFloat32([]float32{
+	err = w.WriteFloat32([]float32{
 		-1.0, -0.99, -0.98, -0.97, 0.0, 0.1, 0.2, 0.3, 0.97, 0.98, 0.99, 1.0,
 	})
 	require.NoError(t, err)
@@ -580,7 +580,7 @@ func TestE2E_Float64_Normal(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedFloat64([]float64{
+	err = w.WriteFloat64([]float64{
 		-1.0, -0.99, 0, 0.1, 0.99, 1.0,
 	})
 	require.NoError(t, err)
@@ -625,7 +625,7 @@ func TestE2E_Float64_Extensible(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedFloat64([]float64{
+	err = w.WriteFloat64([]float64{
 		-1.0, -0.99, -0.98, -0.97, 0.0, 0.1, 0.2, 0.3, 0.97, 0.98, 0.99, 1.0,
 	})
 	require.NoError(t, err)

--- a/wave/writer_test.go
+++ b/wave/writer_test.go
@@ -66,7 +66,7 @@ func TestWriter_Flush_Normal(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedFloat32([]float32{0.0, 1.0, 0.0, -1.0})
+	err = w.WriteFloat32([]float32{0.0, 1.0, 0.0, -1.0})
 	require.NoError(t, err)
 
 	err = w.Flush()
@@ -93,7 +93,7 @@ func TestWriter_Flush_WithPadding(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedUint8([]byte{0, 1, 2})
+	err = w.WriteUint8([]byte{0, 1, 2})
 	require.NoError(t, err)
 
 	err = w.Flush()
@@ -110,7 +110,7 @@ func TestWriter_Flush_InvalidByteCount(t *testing.T) {
 	require.NoError(t, err)
 
 	// 3 bytes with 2 channels is invalid
-	err = w.WriteInterleavedUint8([]byte{0, 1, 2})
+	err = w.WriteUint8([]byte{0, 1, 2})
 	require.NoError(t, err)
 
 	err = w.Flush()
@@ -118,163 +118,163 @@ func TestWriter_Flush_InvalidByteCount(t *testing.T) {
 }
 
 // ------------------------------------------------------------------------- //
-// WriteInterleavedUint8
+// WriteUint8
 // ------------------------------------------------------------------------- //
 
-func TestWriter_WriteInterleavedUint8_Normal(t *testing.T) {
+func TestWriter_WriteUint8_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
 		baseWriter, SampleTypeUint8, 44100,
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedUint8([]byte{0, 1, 2, 3})
+	err = w.WriteUint8([]byte{0, 1, 2, 3})
 	require.NoError(t, err)
 	require.Greater(t, baseWriter.Len(), 0)
 }
 
-func TestWriter_WriteInterleavedUint8_InvalidSampleType(t *testing.T) {
+func TestWriter_WriteUint8_InvalidSampleType(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
 		baseWriter, SampleTypeFloat32, 44100,
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedUint8([]byte{0, 1, 2, 3})
+	err = w.WriteUint8([]byte{0, 1, 2, 3})
 	require.ErrorIs(t, err, ErrWriterExpectedUint8)
 }
 
 // ------------------------------------------------------------------------- //
-// WriteInterleavedInt16
+// WriteInt16
 // ------------------------------------------------------------------------- //
 
-func TestWriter_WriteInterleavedInt16_Normal(t *testing.T) {
+func TestWriter_WriteInt16_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
 		baseWriter, SampleTypeInt16, 44100,
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedInt16([]int16{0, 32737, 0, -32768})
+	err = w.WriteInt16([]int16{0, 32737, 0, -32768})
 	require.NoError(t, err)
 	require.Greater(t, baseWriter.Len(), 0)
 }
 
-func TestWriter_WriteInterleavedInt16_InvalidSampleType(t *testing.T) {
+func TestWriter_WriteInt16_InvalidSampleType(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
 		baseWriter, SampleTypeFloat32, 44100,
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedInt16([]int16{0, 32737, 0, -32768})
+	err = w.WriteInt16([]int16{0, 32737, 0, -32768})
 	require.ErrorIs(t, err, ErrWriterExpectedInt16)
 }
 
 // ------------------------------------------------------------------------- //
-// WriteInterleavedInt24
+// WriteInt24
 // ------------------------------------------------------------------------- //
 
-func TestWriter_WriteInterleavedInt24_Normal(t *testing.T) {
+func TestWriter_WriteInt24_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
 		baseWriter, SampleTypeInt24, 44100,
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedInt24([]int32{0, 8388607, 0, -8388608})
+	err = w.WriteInt24([]int32{0, 8388607, 0, -8388608})
 	require.NoError(t, err)
 	require.Greater(t, baseWriter.Len(), 0)
 }
 
-func TestWriter_WriteInterleavedInt24_InvalidSampleType(t *testing.T) {
+func TestWriter_WriteInt24_InvalidSampleType(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
 		baseWriter, SampleTypeFloat32, 44100,
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedInt24([]int32{0, 8388607, 0, -8388608})
+	err = w.WriteInt24([]int32{0, 8388607, 0, -8388608})
 	require.ErrorIs(t, err, ErrWriterExpectedInt24)
 }
 
 // ------------------------------------------------------------------------- //
-// WriteInterleavedInt32
+// WriteInt32
 // ------------------------------------------------------------------------- //
 
-func TestWriter_WriteInterleavedInt32_Normal(t *testing.T) {
+func TestWriter_WriteInt32_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
 		baseWriter, SampleTypeInt32, 44100,
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedInt32([]int32{0, 2147483647, 0, -2147483648})
+	err = w.WriteInt32([]int32{0, 2147483647, 0, -2147483648})
 	require.NoError(t, err)
 	require.Greater(t, baseWriter.Len(), 0)
 }
 
-func TestWriter_WriteInterleavedInt32_InvalidSampleType(t *testing.T) {
+func TestWriter_WriteInt32_InvalidSampleType(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
 		baseWriter, SampleTypeFloat32, 44100,
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedInt32([]int32{0, 2147483647, 0, -2147483648})
+	err = w.WriteInt32([]int32{0, 2147483647, 0, -2147483648})
 	require.ErrorIs(t, err, ErrWriterExpectedInt32)
 }
 
 // ------------------------------------------------------------------------- //
-// WriteInterleavedFloat32
+// WriteFloat32
 // ------------------------------------------------------------------------- //
 
-func TestWriter_WriteInterleavedFloat32_Normal(t *testing.T) {
+func TestWriter_WriteFloat32_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
 		baseWriter, SampleTypeFloat32, 44100,
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedFloat32([]float32{0.0, 1.0, 0.0, -1.0})
+	err = w.WriteFloat32([]float32{0.0, 1.0, 0.0, -1.0})
 	require.NoError(t, err)
 	require.Greater(t, baseWriter.Len(), 0)
 }
 
-func TestWriter_WriteInterleavedFloat32_InvalidSampleType(t *testing.T) {
+func TestWriter_WriteFloat32_InvalidSampleType(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
 		baseWriter, SampleTypeUint8, 44100,
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedFloat32([]float32{0.0, 1.0, 0.0, -1.0})
+	err = w.WriteFloat32([]float32{0.0, 1.0, 0.0, -1.0})
 	require.ErrorIs(t, err, ErrWriterExpectedFloat32)
 }
 
 // ------------------------------------------------------------------------- //
-// WriteInterleavedFloat64
+// WriteFloat64
 // ------------------------------------------------------------------------- //
 
-func TestWriter_WriteInterleavedFloat64_Normal(t *testing.T) {
+func TestWriter_WriteFloat64_Normal(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
 		baseWriter, SampleTypeFloat64, 44100,
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedFloat64([]float64{0.0, 1.0, 0.0, -1.0})
+	err = w.WriteFloat64([]float64{0.0, 1.0, 0.0, -1.0})
 	require.NoError(t, err)
 	require.Greater(t, baseWriter.Len(), 0)
 }
 
-func TestWriter_WriteInterleavedFloat64_InvalidSampleType(t *testing.T) {
+func TestWriter_WriteFloat64_InvalidSampleType(t *testing.T) {
 	baseWriter := &bytes.Writer{}
 	w, err := NewWriter(
 		baseWriter, SampleTypeUint8, 44100,
 	)
 	require.NoError(t, err)
 
-	err = w.WriteInterleavedFloat64([]float64{0.0, 1.0, 0.0, -1.0})
+	err = w.WriteFloat64([]float64{0.0, 1.0, 0.0, -1.0})
 	require.ErrorIs(t, err, ErrWriterExpectedFloat64)
 }


### PR DESCRIPTION
**Changelog**:
  - Improved documentation, especially about samples and blocks and how data must be organized for this library.
  - Renamed the `WriteInterleavedXXX` methods to `WriteXXX`, as there is some ambiguity about whether "interleaved" might refer to channels or blocks.
  - Cleaned up examples slightly. 