### PR TITLE
Initial Reader Implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        go: ["1.19", "1.20"]
+        go: ["1.19", "1.20", "1.21"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -28,7 +28,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ["1.19", "1.20"]
+        go: ["1.19", "1.20", "1.21"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ process of working with audio data. Key features include:
     - PCM `uint8`, `int16`, `int24`, and `int32` formats
     - IEEE float `float32` and `float64` formats
     - Arbitrary number of audio channels
-    - Arbitrary sample rates
+    - Arbitrary frame (or sample) rates
     - Memory-efficient streaming of audio data to disk (e.g. suitable for 
       real-time audio generation)
   * Quantizers/dequantizers
@@ -71,37 +71,37 @@ example above, the channel count has been set, overriding the default value
 of 1.
 
 ### Working with multiple channels
-In this library, each audio **sample** consists of 1 or more **blocks**, with 
-one block per audio channel. A block is represented as a single number with a
+In this library, each audio **frame** consists of 1 or more **samples**, with 
+one sample per audio channel. A sample is represented as a single number with a
 Go type of `uint8`, `int16`, `int32`, `float32`, or `float64`. 
 
-The API assumes that all *samples* are contiguous, meaning that audio 
-data is organized by *block*, rather than by *channel*.
+The API assumes that all *frames* are contiguous, meaning that audio data is 
+organized by *sample*, rather than by *channel*.
 
-The table below visually demonstrates how blocks are laid out in a slice:
+The table below visually demonstrates how samples are laid out in a slice:
 
 ```text
 +--------+--------+----------------------------+
-| Sample |  Index |                      Value |
+| Frame |  Index |                       Value |
 +--------+--------+----------------------------+
-|        |      0 |        Channel 0 - Block 0 | 
-|        |      1 |        Channel 1 - Block 0 | 
-|   0    |      2 |        Channel 2 - Block 0 | 
+|        |      0 |       Channel 0 - Sample 0 | 
+|        |      1 |       Channel 1 - Sample 0 | 
+|   0    |      2 |       Channel 2 - Sample 0 | 
 |                     ...                      |
-|        |  N - 1 |  Channel (N - 1) - Block 0 |
+|        |  N - 1 | Channel (N - 1) - Sample 0 |
 +--------+--------+----------------------------+
-|        |      N |        Channel 0 - Block 1 | 
-|        |  N + 1 |        Channel 1 - Block 1 | 
-|   1    |  N + 2 |        Channel 2 - Block 1 | 
+|        |      N |       Channel 0 - Sample 1 | 
+|        |  N + 1 |       Channel 1 - Sample 1 | 
+|   1    |  N + 2 |       Channel 2 - Sample 1 | 
 |                     ...                      |
-|        | 2N - 1 |  Channel (N - 1) - Block 1 |
+|        | 2N - 1 | Channel (N - 1) - Sample 1 |
 +--------+--------+----------------------------+
 |                     ...                      |
 ```
 
 Applications that generate multi-channel audio will sometimes choose to keep
-other conventions (e.g. organizing data first by channel and then by block, or 
-using a 2-dimensional array to store blocks). It is the responsibility of the 
+other conventions (e.g. organizing data first by channel and then by sample, or 
+using a 2-dimensional array to store samples). It is the responsibility of the 
 caller to ensure that their audio data is in the format expected by this 
 library.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 # Audio I/O
 
-`audio-io` is a collection of I/O utilities written in Go that simplify the
-process of working with audio data. Key features include:
+`audio-io` is a collection of I/O utilities written in pure Go that enable 
+developers to efficiently work with audio data. Key features include:
   * A `.wav` file writer that supports:
     - PCM `uint8`, `int16`, `int24`, and `int32` formats
     - IEEE float `float32` and `float64` formats
@@ -19,6 +19,10 @@ process of working with audio data. Key features include:
       `float32`, and `float64` audio formats
   * Interleavers/deinterleavers
     - Used to simplify the process of working with multi-channel audio files
+
+## Examples
+Several complete examples that demonstrate how to use this library are included
+in the `examples` folder.
 
 ## Writing wave files
 The `wave.Writer` type can be used to generate .wav files from a set of audio 
@@ -81,22 +85,22 @@ organized by *sample*, rather than by *channel*.
 The table below visually demonstrates how samples are laid out in a slice:
 
 ```text
-+--------+--------+----------------------------+
-| Frame |  Index |                       Value |
-+--------+--------+----------------------------+
-|        |      0 |       Channel 0 - Sample 0 | 
-|        |      1 |       Channel 1 - Sample 0 | 
-|   0    |      2 |       Channel 2 - Sample 0 | 
-|                     ...                      |
-|        |  N - 1 | Channel (N - 1) - Sample 0 |
-+--------+--------+----------------------------+
-|        |      N |       Channel 0 - Sample 1 | 
-|        |  N + 1 |       Channel 1 - Sample 1 | 
-|   1    |  N + 2 |       Channel 2 - Sample 1 | 
-|                     ...                      |
-|        | 2N - 1 | Channel (N - 1) - Sample 1 |
-+--------+--------+----------------------------+
-|                     ...                      |
++--------+--------------+----------------------------+
+|  Frame |  Slice Index |                       Value |
++--------+--------------+----------------------------+
+|        |            0 |       Channel 0 - Sample 0 | 
+|        |            1 |       Channel 1 - Sample 0 | 
+|   0    |            2 |       Channel 2 - Sample 0 | 
+|                        ...                         |
+|        |        N - 1 | Channel (N - 1) - Sample 0 |
++--------+--------------+----------------------------+
+|        |            N |       Channel 0 - Sample 1 | 
+|        |        N + 1 |       Channel 1 - Sample 1 | 
+|   1    |        N + 2 |       Channel 2 - Sample 1 | 
+|                        ...                         |
+|        |       2N - 1 | Channel (N - 1) - Sample 1 |
++--------+--------------+----------------------------+
+|                        ...                         |
 ```
 
 Applications that generate multi-channel audio will sometimes choose to keep
@@ -124,15 +128,11 @@ conversions between audio sample types (e.g. `int32` and `float32`). PCM types,
 those types, while IEEE types (`float32` and `float64`) are assumed to use the
 [-1.0, 1.0] range.
 
-A quick note on `int24`: most programming languages (including Go) don't 
-provide a native 24-bit integer type, so we usually use `int32` as a container 
-type with the understanding that values are expected to fall in the range 
-[-8388608, 8388607]. There is special logic where needed in the library to pack 
-and unpack 24-bit integers as appropriate.
-
-## Examples
-Several complete examples that demonstrate how to use this library are included 
-in the `examples` folder. 
+A quick note on `int24`: most programming languages (including Go) lack a 
+native 24-bit integer type, so we use `int32` as a container type with the 
+understanding that values are expected to fall in the range [-8388608, 8388607]. 
+The library will pack and unpack 24-bit integers (mapping to 3-byte sequences) 
+as needed.
 
 ## Developer Information
 

--- a/examples/stream-reader/main.go
+++ b/examples/stream-reader/main.go
@@ -1,3 +1,23 @@
+// stream-reader demonstrates how to use the audio-io 'core' and 'wave'
+// packages to stream (and process) individual blocks of audio data from a wave
+// file.
+//
+// This example reads blocks of audio data, normalizes those samples
+// (converting to float64), and then calculates some basic statistics for each
+// block. The block-level statistics are used to generate a crude ASCII
+// 'oscillogram' (a representation of the amplitude of the signal over time).
+//
+//	(+) 1.0 + ---------------------------------------- +
+//	        | █                █                 █     |
+//	        | █                █                 █     |
+//	        | █   █   █    █   █    █   █   █    █     |
+//	        | ██ ██   ███  █   ███  █   █   █    █     |
+//	    0.0 + ████████████████████████████████████████ +
+//	        | ██  █   █    █   █    █   █   █    █     |
+//	        | █                                  █     |
+//	        |                                          |
+//	        |                                          |
+//	(-) 1.0 + ---------------------------------------- +
 package main
 
 import (
@@ -21,7 +41,7 @@ func main() {
 	const graphHeight = 9
 
 	// Open the provided file for reading
-	file, err := os.Open("example.wav")
+	file, err := os.Open("voice.wav")
 	if err != nil {
 		failF(err)
 	}
@@ -60,9 +80,9 @@ func main() {
 	minValues := make([]float64, 0)
 	maxValues := make([]float64, 0)
 	for block := range c {
-		min, max := minMax(block)
-		minValues = append(minValues, min)
-		maxValues = append(maxValues, max)
+		minValue, maxValue := minMax(block)
+		minValues = append(minValues, minValue)
+		maxValues = append(maxValues, maxValue)
 	}
 
 	// Just for fun, we'll render a simple time-based visualization of the
@@ -188,17 +208,17 @@ func readNormalizedSamples(
 
 // minMax computes the min and max values for the given slice.
 func minMax(samples []float64) (float64, float64) {
-	min := samples[0]
-	max := samples[0]
+	minValue := samples[0]
+	maxValue := samples[0]
 	for _, s := range samples {
-		if s < min {
-			min = s
+		if s < minValue {
+			minValue = s
 		}
-		if s > max {
-			max = s
+		if s > maxValue {
+			maxValue = s
 		}
 	}
-	return min, max
+	return minValue, maxValue
 }
 
 // drawGraph renders the provided minimum and maximum values as a simple ASCII

--- a/examples/stream-reader/main.go
+++ b/examples/stream-reader/main.go
@@ -202,8 +202,8 @@ func minMax(samples []float64) (float64, float64) {
 }
 
 // drawGraph renders the provided minimum and maximum values as a simple ASCII
-// chart, like the one given below. The x axis represents individual blocks of
-// audio (proportional to time), the y axis represents the max/min amplitudes
+// chart, like the one given below. The x-axis represents individual blocks of
+// audio (proportional to time), the y-axis represents the max/min amplitudes
 // encountered in that block. The height of the graph (in rows) can be provided
 // as input to increase the vertical resolution.
 //
@@ -242,7 +242,7 @@ func drawGraph(minValues []float64, maxValues []float64, height int) {
 	// Linearly map each element of the min/max arrays to a row number and then
 	// fill in all cells between those rows to form a solid vertical bar. (This
 	// is an extremely primitive way of rendering signal amplitudes, but it
-	// will work well enough for this example.
+	// will work well enough for this example).
 	for x := 0; x < width; x++ {
 		maxRow := int((float64(height) * (1 - maxValues[x])) / 2)
 		minRow := int((float64(height) * (1 - minValues[x])) / 2)

--- a/examples/stream-reader/main.go
+++ b/examples/stream-reader/main.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/jonchammer/audio-io/core"
+	"github.com/jonchammer/audio-io/wave"
+)
+
+func main() {
+
+	// We'll divide the audio file into blocks of samples. This constant
+	// determines how many blocks we'll end up with. It will also represent the
+	// width of the graph (measured in characters)
+	const maxBlocks = 80
+
+	// Determines the height of the graph (measured in terminal rows)
+	const graphHeight = 9
+
+	// Open the provided file for reading
+	file, err := os.Open("example.wav")
+	if err != nil {
+		failF(err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	// Create a reader using the file
+	reader := wave.NewReader(file)
+
+	// For the sake of this example, we'll determine the number of samples per
+	// block dynamically. The first 'N - 1' blocks will have 'samplesBerBlock'
+	// samples each, and the last block will consist of however many samples
+	// are left over.
+	header, err := reader.Header()
+	if err != nil {
+		failF(err)
+	}
+	samplesBerBlock := int(header.SampleCount() / (maxBlocks - 1))
+
+	// We'll use a channel to facilitate communication between a background
+	// goroutine (responsible for reading blocks of samples) and the main
+	// goroutine (responsible for calculating some statistics for each block).
+	//
+	// Note that individual audio blocks (not the entire audio file) are kept
+	// in memory. As a result, memory usage is not expected to appreciably grow
+	// while we're streaming.
+	c := make(chan []float64)
+	go func() {
+		err = readNormalizedSamples(c, reader, samplesBerBlock)
+		if err != nil {
+			failF(err)
+		}
+	}()
+
+	minValues := make([]float64, 0)
+	maxValues := make([]float64, 0)
+	for block := range c {
+		min, max := minMax(block)
+		minValues = append(minValues, min)
+		maxValues = append(maxValues, max)
+	}
+
+	// Just for fun, we'll render a simple time-based visualization of the
+	// audio amplitude to the console.
+	fmt.Printf("Processed '%d' audio blocks\n", len(minValues))
+	drawGraph(minValues, maxValues, graphHeight)
+}
+
+// readNormalizedSamples reads blocks of audio samples from 'reader',
+// normalizes them, and pushes the results into 'c'. Each block of samples will
+// have at most 'maxSamples' elements in it. The last block will likely have
+// fewer elements. 'c' will be closed when all samples have been read.
+func readNormalizedSamples(
+	c chan []float64,
+	reader *wave.Reader,
+	maxSamples int,
+) error {
+
+	// Ensure that the channel is closed, even if we fail to read data from
+	// the file.
+	defer close(c)
+
+	// NOTE: If the header has already been read, a cached version will be
+	// returned.
+	header, err := reader.Header()
+	if err != nil {
+		return err
+	}
+
+	// Ensure the sample type is known
+	sampleType, err := header.SampleType()
+	if err != nil {
+		return err
+	}
+
+	switch sampleType {
+	case wave.SampleTypeUint8:
+		{
+			for {
+				data := make([]uint8, maxSamples)
+				samplesRead, err := reader.ReadUint8(data)
+				if err != nil && err == io.EOF {
+					break
+				}
+
+				normalized := core.DequantizeUint8(data[:samplesRead])
+				c <- normalized
+			}
+		}
+
+	case wave.SampleTypeInt16:
+		{
+			for {
+				data := make([]int16, maxSamples)
+				samplesRead, err := reader.ReadInt16(data)
+				if err != nil && err == io.EOF {
+					break
+				}
+
+				normalized := core.DequantizeInt16(data[:samplesRead])
+				c <- normalized
+			}
+		}
+
+	case wave.SampleTypeInt24:
+		{
+			for {
+				data := make([]int32, maxSamples)
+				samplesRead, err := reader.ReadInt24(data)
+				if err != nil && err == io.EOF {
+					break
+				}
+
+				normalized := core.DequantizeInt24(data[:samplesRead])
+				c <- normalized
+			}
+		}
+
+	case wave.SampleTypeInt32:
+		{
+			for {
+				data := make([]int32, maxSamples)
+				samplesRead, err := reader.ReadInt32(data)
+				if err != nil && err == io.EOF {
+					break
+				}
+
+				normalized := core.DequantizeInt32(data[:samplesRead])
+				c <- normalized
+			}
+		}
+
+	case wave.SampleTypeFloat32:
+		{
+			for {
+				data := make([]float32, maxSamples)
+				samplesRead, err := reader.ReadFloat32(data)
+				if err != nil && err == io.EOF {
+					break
+				}
+
+				normalized := core.DequantizeFloat32(data[:samplesRead])
+				c <- normalized
+			}
+		}
+
+	case wave.SampleTypeFloat64:
+		{
+			for {
+				data := make([]float64, maxSamples)
+				samplesRead, err := reader.ReadFloat64(data)
+				if err != nil && err == io.EOF {
+					break
+				}
+
+				c <- data[:samplesRead]
+			}
+		}
+	}
+
+	return nil
+}
+
+// minMax computes the min and max values for the given slice.
+func minMax(samples []float64) (float64, float64) {
+	min := samples[0]
+	max := samples[0]
+	for _, s := range samples {
+		if s < min {
+			min = s
+		}
+		if s > max {
+			max = s
+		}
+	}
+	return min, max
+}
+
+// drawGraph renders the provided minimum and maximum values as a simple ASCII
+// chart, like the one given below. The x axis represents individual blocks of
+// audio (proportional to time), the y axis represents the max/min amplitudes
+// encountered in that block. The height of the graph (in rows) can be provided
+// as input to increase the vertical resolution.
+//
+// NOTE: There are better ways of visualizing audio data, but this method works
+// well enough for this demo.
+//
+// Example output (height = 9):
+//
+//	+1.0 + ---------------------------------------- +
+//	     | █                █                 █     |
+//	     | █                █                 █     |
+//	     | █   █   █    █   █    █   █   █    █     |
+//	     | ██ ██   ███  █   ███  █   █   █    █     |
+//	 0.0 + ████████████████████████████████████████ +
+//	     | ██  █   █    █   █    █   █   █    █     |
+//	     | █                                  █     |
+//	     |                                          |
+//	     |                                          |
+//	-1.0 + ---------------------------------------- +
+func drawGraph(minValues []float64, maxValues []float64, height int) {
+
+	width := len(minValues)
+
+	// This 2D array will be our graph's "canvas". For simplicity when
+	// rendering, we'll assume that (0, 0) is the top left corner of the graph,
+	// meaning that the 'y' axis points downward and the 'x' axis points to
+	// the right.
+	cells := make([][]rune, height)
+	for y := 0; y < height; y++ {
+		cells[y] = make([]rune, width)
+		for x := 0; x < width; x++ {
+			cells[y][x] = ' '
+		}
+	}
+
+	// Linearly map each element of the min/max arrays to a row number and then
+	// fill in all cells between those rows to form a solid vertical bar. (This
+	// is an extremely primitive way of rendering signal amplitudes, but it
+	// will work well enough for this example.
+	for x := 0; x < width; x++ {
+		maxRow := int((float64(height) * (1 - maxValues[x])) / 2)
+		minRow := int((float64(height) * (1 - minValues[x])) / 2)
+		for y := maxRow; y <= minRow; y++ {
+			cells[y][x] = '█'
+		}
+	}
+
+	// Print the graph to the console
+	fmt.Println("+1.0 +", strings.Repeat("-", width), "+")
+	for y := 0; y < height; y++ {
+		leftEdge := "     |"
+		rightEdge := "|"
+		if y == height/2 {
+			leftEdge = " 0.0 +"
+			rightEdge = "+"
+		}
+
+		fmt.Println(leftEdge, string(cells[y]), rightEdge)
+	}
+	fmt.Println("-1.0 +", strings.Repeat("-", width), "+")
+}
+
+func failF(err error) {
+	_, _ = fmt.Fprintln(os.Stderr, err)
+	os.Exit(-1)
+}

--- a/examples/stream-writer/main.go
+++ b/examples/stream-writer/main.go
@@ -1,3 +1,12 @@
+// stream-writer demonstrates how to use the audio-io 'core' and 'wave'
+// packages to generate blocks of audio data that can be streamed to a wave
+// file.
+//
+// Streaming has the potential to be more efficient for larger audio files,
+// since the entire audio file does not have to be stored in memory.
+//
+// Streaming is also useful for cases where the duration of the audio data is
+// unknown at runtime (e.g. when recording from a microphone).
 package main
 
 import (

--- a/examples/wave-reader/main.go
+++ b/examples/wave-reader/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 
 	// Open the provided file for reading
-	file, err := os.Open("voice.wav")
+	file, err := os.Open("example.wav")
 	if err != nil {
 		failF(err)
 	}
@@ -59,7 +59,7 @@ func printWaveMetadata(r *wave.Reader) error {
 	// to one of the wave.SampleTypeXXX constants.
 	sampleType, _ := header.SampleType()
 
-	// Print some relevant metadata for the file.
+	// Print some common metadata for the file.
 	fmt.Printf("Successfully read wave header\n")
 	fmt.Printf("File Size (bytes):      %d\n", header.ReportedFileSizeBytes)
 	fmt.Printf("Sample Type:            %s\n", sampleType)
@@ -81,6 +81,17 @@ func printWaveMetadata(r *wave.Reader) error {
 	}
 	fmt.Printf("Validation:             %s\n", msg)
 	fmt.Println()
+
+	// Print specialized information if we have it
+	if header.CueData != nil {
+		fmt.Println("Cues:")
+		for i, c := range header.CueData.CuePoints {
+			fmt.Printf("%d - Cue ID: %d\n", i, c.ID)
+			fmt.Printf("  - Chunk:  '%s'\n", string(c.FCCChunk[:]))
+			fmt.Printf("  - Offset: %d\n", c.SampleOffset)
+		}
+		fmt.Println()
+	}
 
 	// This library knows how to interpret several common WAVE chunks, but if
 	// a particular chunk isn't recognized, the user has an option to deal with

--- a/examples/wave-reader/main.go
+++ b/examples/wave-reader/main.go
@@ -1,3 +1,9 @@
+// wave-reader demonstrates how to use the audio-io 'core' and 'wave' packages
+// to extract all the normalized audio data from a wave file.
+//
+// This example assumes that the entire wave file can be read into memory at
+// once. See the 'stream-reader' example for a slightly more sophisticated use
+// case (where audio data is read in blocks that can be processed individually).
 package main
 
 import (
@@ -38,11 +44,11 @@ func main() {
 	fmt.Println()
 
 	// Compute some example statistics on the normalized audio data
-	min, max := minMax(normalizedAudioData)
-	factor := math.Max(math.Abs(min), math.Abs(max))
+	minValue, maxValue := minMax(normalizedAudioData)
+	factor := math.Max(math.Abs(minValue), math.Abs(maxValue))
 	gainDb := 20 * math.Log10(factor)
-	fmt.Printf("Min value (normalized): %f\n", min)
-	fmt.Printf("Max value (normalized): %+f\n", max)
+	fmt.Printf("Min value (normalized): %f\n", minValue)
+	fmt.Printf("Max value (normalized): %+f\n", maxValue)
 	fmt.Printf("Estimated gain (dB):    %f\n", gainDb)
 }
 
@@ -195,17 +201,17 @@ func readNormalizedAudioData(r *wave.Reader) ([]float64, error) {
 
 // minMax computes the min and max values for the given slice.
 func minMax(samples []float64) (float64, float64) {
-	min := samples[0]
-	max := samples[0]
+	minValue := samples[0]
+	maxValue := samples[0]
 	for _, s := range samples {
-		if s < min {
-			min = s
+		if s < minValue {
+			minValue = s
 		}
-		if s > max {
-			max = s
+		if s > maxValue {
+			maxValue = s
 		}
 	}
-	return min, max
+	return minValue, maxValue
 }
 
 func failF(err error) {

--- a/examples/wave-reader/main.go
+++ b/examples/wave-reader/main.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"os"
+
+	"github.com/jonchammer/audio-io/core"
+	"github.com/jonchammer/audio-io/wave"
+)
+
+func main() {
+
+	// Open the provided file for reading
+	file, err := os.Open("voice.wav")
+	if err != nil {
+		failF(err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	// Create a reader using the file
+	reader := wave.NewReader(file)
+
+	// Print some useful metadata about the wave file to the console
+	err = printWaveMetadata(reader)
+	if err != nil {
+		failF(err)
+	}
+
+	// Read the audio data as 'normalized' (or dequantized) float64 samples
+	normalizedAudioData, err := readNormalizedAudioData(reader)
+	if err != nil {
+		failF(err)
+	}
+	fmt.Printf("Successfully read '%d' audio samples\n", len(normalizedAudioData))
+	fmt.Println()
+
+	// Compute some example statistics on the normalized audio data
+	min, max := minMax(normalizedAudioData)
+	factor := math.Max(math.Abs(min), math.Abs(max))
+	gainDb := 20 * math.Log10(factor)
+	fmt.Printf("Min value (normalized): %f\n", min)
+	fmt.Printf("Max value (normalized): %+f\n", max)
+	fmt.Printf("Estimated gain (dB):    %f\n", gainDb)
+}
+
+func printWaveMetadata(r *wave.Reader) error {
+
+	// The header contains most relevant metadata, including details on how the
+	// samples should be interpreted.
+	header, err := r.Header()
+	if err != nil {
+		return err
+	}
+
+	// Well-formed wave files should have a known sample type, corresponding
+	// to one of the wave.SampleTypeXXX constants.
+	sampleType, _ := header.SampleType()
+
+	// Print some relevant metadata for the file.
+	fmt.Printf("Successfully read wave header\n")
+	fmt.Printf("File Size (bytes):      %d\n", header.ReportedFileSizeBytes)
+	fmt.Printf("Sample Type:            %s\n", sampleType)
+	fmt.Printf("Bytes per Sample:       %d\n", sampleType.Size())
+	fmt.Printf("Frame Rate:             %d\n", header.FrameRate())
+	fmt.Printf("Bit Rate (bits/second): %d\n", header.BitRate())
+	fmt.Printf("Channel Count:          %d\n", header.ChannelCount())
+	fmt.Printf("Frame Count:            %d\n", header.FrameCount())
+	fmt.Printf("Sample Count:           %d\n", header.SampleCount())
+	fmt.Printf("Play Time:              %v\n", header.PlayTime())
+
+	// We can optionally perform some basic integrity checks on the header to
+	// validate that it is logically consistent. A failed validation check
+	// doesn't necessary mean that the audio data can't be recovered, but it
+	// does mean that the data presented above may not be trustworthy.
+	msg := "PASSED"
+	if err = header.Validate(); err != nil {
+		msg = "FAILED - " + err.Error()
+	}
+	fmt.Printf("Validation:             %s\n", msg)
+	fmt.Println()
+
+	// This library knows how to interpret several common WAVE chunks, but if
+	// a particular chunk isn't recognized, the user has an option to deal with
+	// it themselves.
+	if len(header.AdditionalChunks) != 0 {
+		fmt.Println("Additional Chunks:")
+		for i, c := range header.AdditionalChunks {
+			fmt.Printf("%d - ID:   '%s'\n", i, string(c.ID[:]))
+			fmt.Printf("    Size: %d\n", c.Size)
+		}
+		fmt.Println()
+	}
+
+	return nil
+}
+
+// readNormalizedAudioData demonstrates how to determine the correct data type
+// for the audio samples based on the wave file metadata. In this example, we
+// convert the samples to float64 and dequantize them to the range [-1, 1] so
+// that we can process audio data in a fairly standard way.
+func readNormalizedAudioData(r *wave.Reader) ([]float64, error) {
+
+	// NOTE: If the header has already been read, a cached version will be
+	// returned.
+	header, err := r.Header()
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure the sample type is known
+	sampleType, err := header.SampleType()
+	if err != nil {
+		return nil, err
+	}
+
+	var dequantizedAudioSamples []float64
+
+	switch sampleType {
+	case wave.SampleTypeUint8:
+		{
+			data := make([]uint8, header.SampleCount())
+			_, err = r.ReadUint8(data)
+			if err != nil {
+				return nil, err
+			}
+			dequantizedAudioSamples = core.DequantizeUint8(data)
+		}
+
+	case wave.SampleTypeInt16:
+		{
+			data := make([]int16, header.SampleCount())
+			_, err = r.ReadInt16(data)
+			if err != nil {
+				return nil, err
+			}
+			dequantizedAudioSamples = core.DequantizeInt16(data)
+		}
+
+	case wave.SampleTypeInt24:
+		{
+			data := make([]int32, header.SampleCount())
+			_, err = r.ReadInt24(data)
+			if err != nil {
+				return nil, err
+			}
+			dequantizedAudioSamples = core.DequantizeInt24(data)
+		}
+
+	case wave.SampleTypeInt32:
+		{
+			data := make([]int32, header.SampleCount())
+			_, err = r.ReadInt32(data)
+			if err != nil {
+				return nil, err
+			}
+			dequantizedAudioSamples = core.DequantizeInt32(data)
+		}
+
+	case wave.SampleTypeFloat32:
+		{
+			data := make([]float32, header.SampleCount())
+			_, err = r.ReadFloat32(data)
+			if err != nil {
+				return nil, err
+			}
+			dequantizedAudioSamples = core.DequantizeFloat32(data)
+		}
+
+	case wave.SampleTypeFloat64:
+		{
+			dequantizedAudioSamples = make([]float64, header.SampleCount())
+			_, err = r.ReadFloat64(dequantizedAudioSamples)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return dequantizedAudioSamples, nil
+}
+
+// minMax computes the min and max values for the given slice.
+func minMax(samples []float64) (float64, float64) {
+	min := samples[0]
+	max := samples[0]
+	for _, s := range samples {
+		if s < min {
+			min = s
+		}
+		if s > max {
+			max = s
+		}
+	}
+	return min, max
+}
+
+func failF(err error) {
+	_, _ = fmt.Fprintln(os.Stderr, err)
+	os.Exit(-1)
+}

--- a/examples/wave-writer/main.go
+++ b/examples/wave-writer/main.go
@@ -17,13 +17,13 @@ func main() {
 		duration      = 2 * time.Second
 		sampleRate    = 44100
 		sineFrequency = 440.0 // The note 'A'
-		sineGain      = 0.25  // Amplitude multiplier
+		sineGainDb    = -12.0 // Gain of the signal, measured in decibels
 	)
 
 	// 1. Generate a single channel sine wave for testing. We'll generate the
 	// data using high-precision float64 samples, but we'll quantize the data
 	// before we write it to disk.
-	samples := generateSineWave(duration, sampleRate, sineFrequency, sineGain)
+	samples := generateSineWave(duration, sampleRate, sineFrequency, sineGainDb)
 
 	// 2. Open a file to store the resulting .wav file.
 	f, err := os.Create("example.wav")
@@ -45,15 +45,16 @@ func generateSineWave(
 	duration time.Duration,
 	sampleRate int,
 	frequency float64,
-	gain float64,
+	gainDb float64,
 ) []float64 {
 
 	const Tau = 2 * math.Pi
 
+	factor := math.Pow(10.0, gainDb/20.0)
 	totalSamples := int(duration.Seconds() * float64(sampleRate))
 	data := make([]float64, totalSamples)
 	for i := 0; i < totalSamples; i++ {
-		data[i] = gain * math.Sin(Tau*frequency*(float64(i)/float64(sampleRate)))
+		data[i] = factor * math.Sin(Tau*frequency*(float64(i)/float64(sampleRate)))
 	}
 	return data
 }

--- a/examples/wave-writer/main.go
+++ b/examples/wave-writer/main.go
@@ -1,3 +1,9 @@
+// wave-writer demonstrates how to use the audio-io 'core' and 'wave' packages
+// to generate a simple wave file containing a single channel audio signal.
+//
+// This example assumes that all audio data can be kept in memory at once. See
+// the 'stream-writer' example for a slightly more sophisticated use case (where
+// audio data is generated in blocks that can be written as they're generated).
 package main
 
 import (

--- a/wave/chunks.go
+++ b/wave/chunks.go
@@ -132,12 +132,14 @@ type FormatChunkData struct {
 	// ChannelCount represents the number of channels of audio in the file.
 	ChannelCount uint16
 
-	// The SampleRate is a count of the number of samples to be played per
-	// second (e.g. 44100).
-	SampleRate uint32
+	// The FrameRate is a count of the number of frames to be played per
+	// second (e.g. 44100), independent of the number of channels. Note that
+	// the term "sample rate" is perhaps a bit more common, but we try to avoid
+	// using it because of the ambiguity with multi-channel data.
+	FrameRate uint32
 
 	// ByteRate is a count of the number of bytes to be played per second. It
-	// should be equal to the SampleRate * the number of bytes per sample *
+	// should be equal to the FrameRate * the number of bytes per sample *
 	// ChannelCount.
 	ByteRate uint32
 
@@ -160,7 +162,7 @@ type FormatChunkData struct {
 	//   FormatCode == FormatCodeExtensible
 	//
 	// It is typically used to represent the 'speaker position mask'. See the
-	// wav specification for exact details.
+	// wave specification for exact details.
 	ChannelMask *uint32
 
 	// SubFormat should be defined (non-nil) if:
@@ -172,7 +174,7 @@ type FormatChunkData struct {
 
 func NewFormatChunkData(
 	channelCount uint16,
-	sampleRate uint32,
+	frameRate uint32,
 	sampleType SampleType,
 ) FormatChunkData {
 
@@ -183,7 +185,7 @@ func NewFormatChunkData(
 	// Calculate some common values needed for the format chunk
 	bitsPerSample := uint16(sampleSizeBytes * 8)
 	blockAlign := uint16(sampleSizeBytes) * channelCount
-	bytesPerSecond := sampleRate * uint32(blockAlign)
+	bytesPerSecond := frameRate * uint32(blockAlign)
 
 	// We'll use the extensible format when it applies
 	isExtensible := channelCount > 2 ||
@@ -205,7 +207,7 @@ func NewFormatChunkData(
 	return FormatChunkData{
 		FormatCode:         formatCode,
 		ChannelCount:       channelCount,
-		SampleRate:         sampleRate,
+		FrameRate:          frameRate,
 		ByteRate:           bytesPerSecond,
 		BlockAlign:         blockAlign,
 		BitsPerSample:      bitsPerSample,
@@ -251,7 +253,7 @@ func (c *FormatChunkData) Serialize() ([]byte, error) {
 
 	writeUint16(buffer, uint16(c.FormatCode))
 	writeUint16(buffer, c.ChannelCount)
-	writeUint32(buffer, c.SampleRate)
+	writeUint32(buffer, c.FrameRate)
 	writeUint32(buffer, c.ByteRate)
 	writeUint16(buffer, c.BlockAlign)
 	writeUint16(buffer, c.BitsPerSample)

--- a/wave/chunks.go
+++ b/wave/chunks.go
@@ -197,6 +197,7 @@ var (
 	FormatChunkID                = [4]byte{'f', 'm', 't', ' '}
 	ErrFmtChunkMissingSubFormat  = errors.New("sub format is expected, but not present")
 	ErrFmtChunkInvalidExtensible = errors.New("extensible format requires that ValidBitsPerSample, ChannelMask, and SubFormat be set")
+	ErrFmtChunkCorruptedPayload  = errors.New("detected corrupted 'fmt' payload")
 )
 
 // NewFormatChunk returns a 'fmt' Chunk containing the given FormatChunkData.
@@ -387,7 +388,7 @@ func DeserializeFormatChunk(data []byte) (*FormatChunkData, error) {
 		minExtensibleSize               = 22
 	)
 	if len(data) < minFactPayloadSize {
-		return nil, errors.New("detected corrupted 'fmt' payload")
+		return nil, ErrFmtChunkCorruptedPayload
 	}
 
 	formatCode := FormatCode(readUint16(data[:2]))
@@ -440,6 +441,8 @@ func DeserializeFormatChunk(data []byte) (*FormatChunkData, error) {
 
 var (
 	FactChunkID = [4]byte{'f', 'a', 'c', 't'}
+
+	ErrFactChunkCorruptedPayload = errors.New("detected corrupted 'fact' payload")
 )
 
 // NewFactChunk returns a 'fact' Chunk containing the given FactChunkData.
@@ -479,7 +482,7 @@ func (c FactChunkData) Serialize() []byte {
 func DeserializeFactChunk(data []byte) (*FactChunkData, error) {
 
 	if len(data) < 4 {
-		return nil, errors.New("detected corrupted 'fact' payload")
+		return nil, ErrFactChunkCorruptedPayload
 	}
 
 	return &FactChunkData{
@@ -516,6 +519,12 @@ func NewDataChunkHeader(dataSize uint32) Chunk {
 func uint32ToBytes(val uint32) []byte {
 	scratch := make([]byte, 4)
 	binary.LittleEndian.PutUint32(scratch, val)
+	return scratch
+}
+
+func uint16ToBytes(val uint16) []byte {
+	scratch := make([]byte, 2)
+	binary.LittleEndian.PutUint16(scratch, val)
 	return scratch
 }
 

--- a/wave/chunks_test.go
+++ b/wave/chunks_test.go
@@ -30,7 +30,7 @@ func TestChunk_Serialize(t *testing.T) {
 
 func TestRIFFChunkData_Serialize_Normal(t *testing.T) {
 	data := RIFFChunkData{
-		subChunks: []Chunk{
+		SubChunks: []Chunk{
 			{
 				ID:   [4]byte{'a', 'b', 'c', 'd'},
 				Size: 4,

--- a/wave/chunks_test.go
+++ b/wave/chunks_test.go
@@ -74,7 +74,7 @@ func TestNewFormatChunkData_Uint8(t *testing.T) {
 	require.Equal(t, FormatChunkData{
 		FormatCode:         FormatCodePCM,
 		ChannelCount:       2,
-		SampleRate:         44100,
+		FrameRate:          44100,
 		ByteRate:           88200,
 		BlockAlign:         2,
 		BitsPerSample:      8,
@@ -91,7 +91,7 @@ func TestNewFormatChunkData_Uint8(t *testing.T) {
 	require.Equal(t, FormatChunkData{
 		FormatCode:         FormatCodeExtensible,
 		ChannelCount:       4,
-		SampleRate:         44100,
+		FrameRate:          44100,
 		ByteRate:           176400,
 		BlockAlign:         4,
 		BitsPerSample:      8,
@@ -108,7 +108,7 @@ func TestNewFormatChunkData_Int16(t *testing.T) {
 	require.Equal(t, FormatChunkData{
 		FormatCode:         FormatCodePCM,
 		ChannelCount:       2,
-		SampleRate:         44100,
+		FrameRate:          44100,
 		ByteRate:           176400,
 		BlockAlign:         4,
 		BitsPerSample:      16,
@@ -125,7 +125,7 @@ func TestNewFormatChunkData_Int16(t *testing.T) {
 	require.Equal(t, FormatChunkData{
 		FormatCode:         FormatCodeExtensible,
 		ChannelCount:       4,
-		SampleRate:         44100,
+		FrameRate:          44100,
 		ByteRate:           352800,
 		BlockAlign:         8,
 		BitsPerSample:      16,
@@ -145,7 +145,7 @@ func TestNewFormatChunkData_Int24(t *testing.T) {
 	require.Equal(t, FormatChunkData{
 		FormatCode:         FormatCodeExtensible,
 		ChannelCount:       2,
-		SampleRate:         44100,
+		FrameRate:          44100,
 		ByteRate:           264600,
 		BlockAlign:         6,
 		BitsPerSample:      24,
@@ -165,7 +165,7 @@ func TestNewFormatChunkData_Int32(t *testing.T) {
 	require.Equal(t, FormatChunkData{
 		FormatCode:         FormatCodeExtensible,
 		ChannelCount:       2,
-		SampleRate:         44100,
+		FrameRate:          44100,
 		ByteRate:           352800,
 		BlockAlign:         8,
 		BitsPerSample:      32,
@@ -182,7 +182,7 @@ func TestNewFormatChunkData_Float32(t *testing.T) {
 	require.Equal(t, FormatChunkData{
 		FormatCode:         FormatCodeIEEEFloat,
 		ChannelCount:       2,
-		SampleRate:         44100,
+		FrameRate:          44100,
 		ByteRate:           352800,
 		BlockAlign:         8,
 		BitsPerSample:      32,
@@ -199,7 +199,7 @@ func TestNewFormatChunkData_Float32(t *testing.T) {
 	require.Equal(t, FormatChunkData{
 		FormatCode:         FormatCodeExtensible,
 		ChannelCount:       4,
-		SampleRate:         44100,
+		FrameRate:          44100,
 		ByteRate:           705600,
 		BlockAlign:         16,
 		BitsPerSample:      32,
@@ -216,7 +216,7 @@ func TestNewFormatChunkData_Float64(t *testing.T) {
 	require.Equal(t, FormatChunkData{
 		FormatCode:         FormatCodeIEEEFloat,
 		ChannelCount:       2,
-		SampleRate:         44100,
+		FrameRate:          44100,
 		ByteRate:           705600,
 		BlockAlign:         16,
 		BitsPerSample:      64,
@@ -233,7 +233,7 @@ func TestNewFormatChunkData_Float64(t *testing.T) {
 	require.Equal(t, FormatChunkData{
 		FormatCode:         FormatCodeExtensible,
 		ChannelCount:       4,
-		SampleRate:         44100,
+		FrameRate:          44100,
 		ByteRate:           1411200,
 		BlockAlign:         32,
 		BitsPerSample:      64,
@@ -304,7 +304,7 @@ func TestFormatChunkData_Serialize_PCM(t *testing.T) {
 	require.Equal(t, 16, len(result))
 	require.Equal(t, uint16(data.FormatCode), binary.LittleEndian.Uint16(result[:2]))
 	require.Equal(t, data.ChannelCount, binary.LittleEndian.Uint16(result[2:4]))
-	require.Equal(t, data.SampleRate, binary.LittleEndian.Uint32(result[4:8]))
+	require.Equal(t, data.FrameRate, binary.LittleEndian.Uint32(result[4:8]))
 	require.Equal(t, data.ByteRate, binary.LittleEndian.Uint32(result[8:12]))
 	require.Equal(t, data.BlockAlign, binary.LittleEndian.Uint16(result[12:14]))
 	require.Equal(t, data.BitsPerSample, binary.LittleEndian.Uint16(result[14:16]))
@@ -320,7 +320,7 @@ func TestFormatChunkData_Serialize_IEEEFloat(t *testing.T) {
 	require.Equal(t, 18, len(result))
 	require.Equal(t, uint16(data.FormatCode), binary.LittleEndian.Uint16(result[:2]))
 	require.Equal(t, data.ChannelCount, binary.LittleEndian.Uint16(result[2:4]))
-	require.Equal(t, data.SampleRate, binary.LittleEndian.Uint32(result[4:8]))
+	require.Equal(t, data.FrameRate, binary.LittleEndian.Uint32(result[4:8]))
 	require.Equal(t, data.ByteRate, binary.LittleEndian.Uint32(result[8:12]))
 	require.Equal(t, data.BlockAlign, binary.LittleEndian.Uint16(result[12:14]))
 	require.Equal(t, data.BitsPerSample, binary.LittleEndian.Uint16(result[14:16]))
@@ -337,7 +337,7 @@ func TestFormatChunkData_Serialize_Extensible(t *testing.T) {
 	require.Equal(t, 40, len(result))
 	require.Equal(t, uint16(data.FormatCode), binary.LittleEndian.Uint16(result[:2]))
 	require.Equal(t, data.ChannelCount, binary.LittleEndian.Uint16(result[2:4]))
-	require.Equal(t, data.SampleRate, binary.LittleEndian.Uint32(result[4:8]))
+	require.Equal(t, data.FrameRate, binary.LittleEndian.Uint32(result[4:8]))
 	require.Equal(t, data.ByteRate, binary.LittleEndian.Uint32(result[8:12]))
 	require.Equal(t, data.BlockAlign, binary.LittleEndian.Uint16(result[12:14]))
 	require.Equal(t, data.BitsPerSample, binary.LittleEndian.Uint16(result[14:16]))

--- a/wave/chunks_test.go
+++ b/wave/chunks_test.go
@@ -68,10 +68,10 @@ func TestRIFFChunkData_Serialize_Empty(t *testing.T) {
 func TestReadRIFFChunk_Normal(t *testing.T) {
 
 	var payload bytes.Buffer
-	payload.Write(RIFFChunkID[:])     // "RIFF"
-	payload.Write(uint32ToBytes(100)) // Example file size
-	payload.Write(WaveID[:])          // "WAVE"
-	payload.Write([]byte{             // Add a few example chunks
+	payload.Write(RIFFChunkID[:])    // "RIFF"
+	payload.Write(uint32ToBytes(78)) // Example file size
+	payload.Write(WaveID[:])         // "WAVE"
+	payload.Write([]byte{            // Add a few example chunks
 		'a', 'b', 'c', 'd',
 		0x04, 0x00, 0x00, 0x00,
 		0x01, 0x02, 0x03, 0x04,
@@ -81,10 +81,11 @@ func TestReadRIFFChunk_Normal(t *testing.T) {
 	})
 	payload.Write(DataChunkID[:])    // "data"
 	payload.Write(uint32ToBytes(42)) // Data size in bytes
+	payload.Write(make([]byte, 42))
 
 	fileSize, riffChunkData, err := ReadRIFFChunk(bytes.NewReader(payload.Bytes()))
 	require.NoError(t, err)
-	require.Equal(t, uint32(100+8), fileSize) // +8 for the RIFF header
+	require.Equal(t, uint32(78+8), fileSize) // +8 for the RIFF header
 	require.NotNil(t, riffChunkData)
 	require.Equal(t, 3, len(riffChunkData.SubChunks))
 

--- a/wave/header.go
+++ b/wave/header.go
@@ -20,6 +20,10 @@ type Header struct {
 	// wave files will have 'fact' chunks.
 	FactData *FactChunkData
 
+	// Data read from the 'cue ' chunk in the wave file (if present). Not all
+	// wave files will have 'cue ' chunks.
+	CueData *CueChunkData
+
 	// Represents the total number of bytes of audio data that can be read from
 	// this wave file.
 	DataBytes uint32
@@ -36,6 +40,7 @@ func parseHeaderFromRIFFChunk(
 
 	var formatChunk *FormatChunkData
 	var factChunk *FactChunkData
+	var cueChunk *CueChunkData
 	var dataBytes uint32
 	var additionalChunks []Chunk
 	var err error
@@ -52,6 +57,13 @@ func parseHeaderFromRIFFChunk(
 		case FactChunkID:
 			{
 				factChunk, err = DeserializeFactChunk(chunk.Body)
+				if err != nil {
+					return nil, err
+				}
+			}
+		case CueChunkID:
+			{
+				cueChunk, err = DeserializeCueChunkData(chunk.Body)
 				if err != nil {
 					return nil, err
 				}
@@ -74,6 +86,7 @@ func parseHeaderFromRIFFChunk(
 		ReportedFileSizeBytes: totalFileSize,
 		FormatData:            *formatChunk,
 		FactData:              factChunk,
+		CueData:               cueChunk,
 		DataBytes:             dataBytes,
 		AdditionalChunks:      additionalChunks,
 	}, nil

--- a/wave/header.go
+++ b/wave/header.go
@@ -1,0 +1,128 @@
+package wave
+
+import (
+	"fmt"
+	"time"
+)
+
+// A Header is a preprocessed view of the beginning of a wave file, typically
+// used when reading wave files (as opposed to writing them).
+type Header struct {
+
+	// Data read from the 'fmt' chunk in the wave file
+	FormatData FormatChunkData
+
+	// Data read from the 'fact' chunk in the wave file (if present). Not all
+	// wave files will have 'fact' chunks.
+	FactData *FactChunkData
+
+	// Represents the total number of bytes of audio data that can be read from
+	// this wave file.
+	DataBytes uint32
+
+	// Contains any Chunks that were not explicitly handled by this library.
+	AdditionalChunks []Chunk
+}
+
+// Validate performs a series of cross-calculations on this Header to ensure
+// that it is internally consistent. If Validate returns nil, this Header has
+// passed all checks. If Validate returns an error, that error will describe
+// what integrity check failed.
+func (h *Header) Validate() error {
+
+	m := uint32(h.FormatData.BitsPerSample / 8)
+
+	// Format code
+	if !h.FormatData.FormatCode.IsValid() {
+		return fmt.Errorf("format code: '%d' was not recognized", h.FormatData.FormatCode)
+	}
+
+	// Bytes per second
+	expectedByteRate := h.FormatData.FrameRate * m * uint32(h.FormatData.ChannelCount)
+	if h.FormatData.ByteRate != expectedByteRate {
+		return fmt.Errorf(
+			"byte rate: '%d' did not match expected result: '%d'",
+			h.FormatData.ByteRate,
+			expectedByteRate,
+		)
+	}
+
+	// Block align
+	expectedBlockAlign := uint16(m) * h.FormatData.ChannelCount
+	if h.FormatData.BlockAlign != expectedBlockAlign {
+		return fmt.Errorf(
+			"block align: '%d' did not match expected result: '%d'",
+			h.FormatData.BlockAlign,
+			expectedBlockAlign,
+		)
+	}
+
+	return nil
+}
+
+// SampleType returns the SampleType that should be used when reading data
+// associated with this Header.
+func (h *Header) SampleType() (SampleType, error) {
+	fc, err := h.FormatData.EffectiveFormatCode()
+	if err != nil {
+		return SampleType(-1), err
+	}
+
+	if fc == FormatCodePCM {
+		switch h.FormatData.BitsPerSample {
+		case 8:
+			return SampleTypeUint8, nil
+		case 16:
+			return SampleTypeInt16, nil
+		case 24:
+			return SampleTypeInt24, nil
+		case 32:
+			return SampleTypeInt32, nil
+		default:
+			return SampleType(-1), fmt.Errorf("unknown PCM type: '%d' bits per sample", h.FormatData.BitsPerSample)
+		}
+	}
+
+	// IEEE float
+	switch h.FormatData.BitsPerSample {
+	case 32:
+		return SampleTypeFloat32, nil
+	case 64:
+		return SampleTypeFloat64, nil
+	default:
+		return SampleType(-1), fmt.Errorf("unknown IEEE type: '%d' bits per sample", h.FormatData.BitsPerSample)
+	}
+}
+
+// FrameRate returns frame rate for the wave file associated with this header,
+// measured in frames/second.
+func (h *Header) FrameRate() uint32 {
+	return h.FormatData.FrameRate
+}
+
+// ChannelCount returns the number of channels of audio data present in the
+// wave file associated with this header. The channel count also determines
+// the number of blocks that must be read to return a single sample.
+func (h *Header) ChannelCount() uint16 {
+	return h.FormatData.ChannelCount
+}
+
+// FrameCount returns the total number of audio frames present in the wave file
+// associated with this header.
+func (h *Header) FrameCount() uint32 {
+	return h.DataBytes / uint32(h.FormatData.BlockAlign)
+}
+
+// SampleCount returns the total number of samples present in the wave file
+// associated with this header.
+func (h *Header) SampleCount() uint32 {
+	return h.DataBytes / uint32(h.FormatData.BitsPerSample/8)
+}
+
+// PlayTime estimates the length of the wave file associated with this header.
+func (h *Header) PlayTime() time.Duration {
+
+	// Calculate value in seconds, but convert to nanoseconds for time.Duration
+	seconds := float64(h.FrameCount()) / float64(h.FormatData.FrameRate)
+	return time.Duration(seconds * 1e9)
+}

--- a/wave/header.go
+++ b/wave/header.go
@@ -57,6 +57,18 @@ func (h *Header) Validate() error {
 		)
 	}
 
+	// Sample frames
+	if h.FactData != nil {
+		expectedSampleFrames := h.FrameCount()
+		if h.FactData.SampleFrames != expectedSampleFrames {
+			return fmt.Errorf(
+				"sample frames: '%d' did not match expected result: '%d'",
+				h.FactData.SampleFrames,
+				expectedSampleFrames,
+			)
+		}
+	}
+
 	return nil
 }
 

--- a/wave/header.go
+++ b/wave/header.go
@@ -167,6 +167,20 @@ func (h *Header) FrameRate() uint32 {
 	return h.FormatData.FrameRate
 }
 
+// ByteRate returns the byte rate for the wave file associated with this header,
+// measured in bytes/second.
+func (h *Header) ByteRate() uint32 {
+	return h.FormatData.ByteRate
+}
+
+// BitRate returns the bit rate for the wave file associated with this header,
+// measured in bits/second.
+func (h *Header) BitRate() uint64 {
+
+	// NOTE: Returning uint64 to eliminate chances of overflow
+	return uint64(h.FormatData.ByteRate) * 8
+}
+
 // ChannelCount returns the number of channels of audio data present in the
 // wave file associated with this header. The channel count also determines
 // the number of blocks that must be read to return a single sample.

--- a/wave/reader.go
+++ b/wave/reader.go
@@ -34,13 +34,24 @@ func NewReader(
 
 func (r *Reader) Header() (*Header, error) {
 
-	// When the header has already been read, we can return it directly
-	if r.header != nil {
-		return r.header, nil
-	}
+	// If we haven't yet read the header, do that first. Results will be cached
+	// after the first invocation.
+	if r.header == nil {
 
-	// Otherwise, we'll have to read it from the base reader
-	// TODO: Fill in
+		// Read the raw RIFF chunk data from the base reader.
+		fileSize, riffData, err := ReadRIFFChunk(r.baseReader)
+		if err != nil {
+			return nil, err
+		}
+
+		// Parse the RIFF chunk as a Header.
+		header, err := parseHeaderFromRIFFChunk(fileSize, riffData)
+		if err != nil {
+			return nil, err
+		}
+		
+		r.header = header
+	}
 
 	return r.header, nil
 }

--- a/wave/reader.go
+++ b/wave/reader.go
@@ -1,11 +1,14 @@
 package wave
 
 import (
+	"encoding/binary"
+	"errors"
 	"io"
 )
 
 type Reader struct {
 	baseReader io.Reader
+	header     *Header
 }
 
 func NewReader(
@@ -17,15 +20,68 @@ func NewReader(
 }
 
 func (r *Reader) Header() (*Header, error) {
-	return nil, nil
+
+	// When the header has already been read, we can return it directly
+	if r.header != nil {
+		return r.header, nil
+	}
+
+	// Otherwise, we'll have to read it from the base reader
+	// TODO: Fill in
+
+	return r.header, nil
 }
 
 func (r *Reader) ReadUint8(data []uint8) (int, error) {
-	return 0, nil
+
+	// Make sure we've read the header already
+	header, err := r.Header()
+	if err != nil {
+		return 0, err
+	}
+
+	// Verify that the sample type is correct
+	sampleType, err := header.SampleType()
+	if err != nil {
+		return 0, err
+	}
+	if sampleType != SampleTypeUint8 {
+		return 0, errors.New("wave format is not uint8")
+	}
+
+	// For uint8 data, we can read directly into the buffer given by the caller.
+	return r.baseReader.Read(data)
 }
 
 func (r *Reader) ReadInt16(data []int16) (int, error) {
-	return 0, nil
+
+	// Make sure we've read the header already
+	header, err := r.Header()
+	if err != nil {
+		return 0, err
+	}
+
+	// Verify that the sample type is correct
+	sampleType, err := header.SampleType()
+	if err != nil {
+		return 0, err
+	}
+	if sampleType != SampleTypeInt16 {
+		return 0, errors.New("wave format is not int16")
+	}
+
+	n := sampleType.Size()
+	maxBytes := len(data) * n
+	buffer := make([]byte, maxBytes)
+	bytesRead, err := io.ReadFull(r.baseReader, buffer)
+	samplesRead := bytesRead / n
+	for i := 0; i < samplesRead; i++ {
+		data[i] = int16(binary.LittleEndian.Uint16(buffer[n*i:]))
+	}
+	if err == io.ErrUnexpectedEOF {
+		err = nil
+	}
+	return samplesRead, err
 }
 
 func (r *Reader) ReadInt24(data []int32) (int, error) {
@@ -33,7 +89,34 @@ func (r *Reader) ReadInt24(data []int32) (int, error) {
 }
 
 func (r *Reader) ReadInt32(data []int32) (int, error) {
-	return 0, nil
+
+	// Make sure we've read the header already
+	header, err := r.Header()
+	if err != nil {
+		return 0, err
+	}
+
+	// Verify that the sample type is correct
+	sampleType, err := header.SampleType()
+	if err != nil {
+		return 0, err
+	}
+	if sampleType != SampleTypeInt32 {
+		return 0, errors.New("wave format is not int32")
+	}
+
+	n := sampleType.Size()
+	maxBytes := len(data) * n
+	buffer := make([]byte, maxBytes)
+	bytesRead, err := io.ReadFull(r.baseReader, buffer)
+	samplesRead := bytesRead / n
+	for i := 0; i < samplesRead; i++ {
+		data[i] = int32(binary.LittleEndian.Uint32(buffer[n*i:]))
+	}
+	if err == io.ErrUnexpectedEOF {
+		err = nil
+	}
+	return samplesRead, err
 }
 
 func (r *Reader) ReadFloat32(data []float32) (int, error) {

--- a/wave/reader.go
+++ b/wave/reader.go
@@ -1,0 +1,45 @@
+package wave
+
+import (
+	"io"
+)
+
+type Reader struct {
+	baseReader io.Reader
+}
+
+func NewReader(
+	baseReader io.Reader,
+) (*Reader, error) {
+	return &Reader{
+		baseReader: baseReader,
+	}, nil
+}
+
+func (r *Reader) Header() (*Header, error) {
+	return nil, nil
+}
+
+func (r *Reader) ReadUint8(data []uint8) (int, error) {
+	return 0, nil
+}
+
+func (r *Reader) ReadInt16(data []int16) (int, error) {
+	return 0, nil
+}
+
+func (r *Reader) ReadInt24(data []int32) (int, error) {
+	return 0, nil
+}
+
+func (r *Reader) ReadInt32(data []int32) (int, error) {
+	return 0, nil
+}
+
+func (r *Reader) ReadFloat32(data []float32) (int, error) {
+	return 0, nil
+}
+
+func (r *Reader) ReadFloat64(data []float64) (int, error) {
+	return 0, nil
+}

--- a/wave/reader.go
+++ b/wave/reader.go
@@ -4,11 +4,22 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"math"
+)
+
+var (
+	ErrReaderUnexpectedUint8   = errors.New("wave header indicates that this file does not use uint8 samples")
+	ErrReaderUnexpectedInt16   = errors.New("wave header indicates that this file does not use int16 samples")
+	ErrReaderUnexpectedInt24   = errors.New("wave header indicates that this file does not use int24 samples")
+	ErrReaderUnexpectedInt32   = errors.New("wave header indicates that this file does not use int32 samples")
+	ErrReaderUnexpectedFloat32 = errors.New("wave header indicates that this file does not use float32 samples")
+	ErrReaderUnexpectedFloat64 = errors.New("wave header indicates that this file does not use float64 samples")
 )
 
 type Reader struct {
 	baseReader io.Reader
 	header     *Header
+	buffer     []byte
 }
 
 func NewReader(
@@ -16,6 +27,8 @@ func NewReader(
 ) (*Reader, error) {
 	return &Reader{
 		baseReader: baseReader,
+		header:     nil,
+		buffer:     nil,
 	}, nil
 }
 
@@ -46,10 +59,11 @@ func (r *Reader) ReadUint8(data []uint8) (int, error) {
 		return 0, err
 	}
 	if sampleType != SampleTypeUint8 {
-		return 0, errors.New("wave format is not uint8")
+		return 0, ErrReaderUnexpectedUint8
 	}
 
-	// For uint8 data, we can read directly into the buffer given by the caller.
+	// For uint8 data, we can read directly into the slice provided by the
+	// caller. No buffering is required.
 	return r.baseReader.Read(data)
 }
 
@@ -67,25 +81,41 @@ func (r *Reader) ReadInt16(data []int16) (int, error) {
 		return 0, err
 	}
 	if sampleType != SampleTypeInt16 {
-		return 0, errors.New("wave format is not int16")
+		return 0, ErrReaderUnexpectedInt16
 	}
 
 	n := sampleType.Size()
-	maxBytes := len(data) * n
-	buffer := make([]byte, maxBytes)
-	bytesRead, err := io.ReadFull(r.baseReader, buffer)
+	bytesRead, err := r.readChunk(len(data) * n)
 	samplesRead := bytesRead / n
 	for i := 0; i < samplesRead; i++ {
-		data[i] = int16(binary.LittleEndian.Uint16(buffer[n*i:]))
-	}
-	if err == io.ErrUnexpectedEOF {
-		err = nil
+		data[i] = int16(binary.LittleEndian.Uint16(r.buffer[n*i:]))
 	}
 	return samplesRead, err
 }
 
 func (r *Reader) ReadInt24(data []int32) (int, error) {
-	return 0, nil
+
+	// Make sure we've read the header already
+	header, err := r.Header()
+	if err != nil {
+		return 0, err
+	}
+
+	// Verify that the sample type is correct
+	sampleType, err := header.SampleType()
+	if err != nil {
+		return 0, err
+	}
+	if sampleType != SampleTypeInt24 {
+		return 0, ErrReaderUnexpectedInt24
+	}
+
+	n := sampleType.Size()
+	bytesRead, err := r.readChunk(len(data) * n)
+	samplesRead := bytesRead / n
+	extraBytes := bytesRead % n
+	_ = ReadPackedInt24Into(r.buffer[:(bytesRead-extraBytes)], data[:samplesRead])
+	return samplesRead, err
 }
 
 func (r *Reader) ReadInt32(data []int32) (int, error) {
@@ -102,27 +132,93 @@ func (r *Reader) ReadInt32(data []int32) (int, error) {
 		return 0, err
 	}
 	if sampleType != SampleTypeInt32 {
-		return 0, errors.New("wave format is not int32")
+		return 0, ErrReaderUnexpectedInt32
 	}
 
 	n := sampleType.Size()
-	maxBytes := len(data) * n
-	buffer := make([]byte, maxBytes)
-	bytesRead, err := io.ReadFull(r.baseReader, buffer)
+	bytesRead, err := r.readChunk(len(data) * n)
 	samplesRead := bytesRead / n
 	for i := 0; i < samplesRead; i++ {
-		data[i] = int32(binary.LittleEndian.Uint32(buffer[n*i:]))
-	}
-	if err == io.ErrUnexpectedEOF {
-		err = nil
+		data[i] = int32(binary.LittleEndian.Uint32(r.buffer[n*i:]))
 	}
 	return samplesRead, err
 }
 
 func (r *Reader) ReadFloat32(data []float32) (int, error) {
-	return 0, nil
+
+	// Make sure we've read the header already
+	header, err := r.Header()
+	if err != nil {
+		return 0, err
+	}
+
+	// Verify that the sample type is correct
+	sampleType, err := header.SampleType()
+	if err != nil {
+		return 0, err
+	}
+	if sampleType != SampleTypeFloat32 {
+		return 0, ErrReaderUnexpectedFloat32
+	}
+
+	n := sampleType.Size()
+	bytesRead, err := r.readChunk(len(data) * n)
+	samplesRead := bytesRead / n
+	for i := 0; i < samplesRead; i++ {
+		data[i] = math.Float32frombits(binary.LittleEndian.Uint32(r.buffer[n*i:]))
+	}
+	return samplesRead, err
 }
 
 func (r *Reader) ReadFloat64(data []float64) (int, error) {
-	return 0, nil
+
+	// Make sure we've read the header already
+	header, err := r.Header()
+	if err != nil {
+		return 0, err
+	}
+
+	// Verify that the sample type is correct
+	sampleType, err := header.SampleType()
+	if err != nil {
+		return 0, err
+	}
+	if sampleType != SampleTypeFloat64 {
+		return 0, ErrReaderUnexpectedFloat64
+	}
+
+	n := sampleType.Size()
+	bytesRead, err := r.readChunk(len(data) * n)
+	samplesRead := bytesRead / n
+	for i := 0; i < samplesRead; i++ {
+		data[i] = math.Float64frombits(binary.LittleEndian.Uint64(r.buffer[n*i:]))
+	}
+	return samplesRead, err
+}
+
+// readChunk pulls up to 'maxBytes' from the base reader into this reader's
+// internal buffer, returning the number of bytes actually read and an error.
+//
+// readChunk has the same semantics as io.ReadFull:
+//   - If 'maxBytes' are read, 'maxBytes' is returned with no error
+//   - If fewer than 'maxBytes' are read (but more than 0), the number of bytes
+//     read will be returned with an io.ErrUnexpectedEOF error.
+//   - If 0 bytes are read, 0 bytes will be returned with an io.EOF error.
+func (r *Reader) readChunk(
+	maxBytes int,
+) (int, error) {
+
+	// Buffer management. If we haven't yet allocated a buffer, we'll do so
+	// now. If the user is now asking for more bytes than they have in the
+	// past, we'll increase the size of the buffer.
+	if r.buffer == nil {
+		r.buffer = make([]byte, maxBytes)
+	} else if len(r.buffer) < maxBytes {
+		r.buffer = append(make([]byte, maxBytes), r.buffer...)
+	}
+
+	// Read as many as 'maxBytes' elements into the internal buffer. Note that
+	// the buffer may actually have space for more elements if 'readChunk'
+	// was called earlier with a larger value for 'maxBytes'.
+	return io.ReadFull(r.baseReader, r.buffer[:maxBytes])
 }

--- a/wave/reader.go
+++ b/wave/reader.go
@@ -49,7 +49,7 @@ func (r *Reader) Header() (*Header, error) {
 		if err != nil {
 			return nil, err
 		}
-		
+
 		r.header = header
 	}
 
@@ -225,7 +225,7 @@ func (r *Reader) readChunk(
 	if r.buffer == nil {
 		r.buffer = make([]byte, maxBytes)
 	} else if len(r.buffer) < maxBytes {
-		r.buffer = append(make([]byte, maxBytes), r.buffer...)
+		r.buffer = append(make([]byte, 0, maxBytes), r.buffer...)
 	}
 
 	// Read as many as 'maxBytes' elements into the internal buffer. Note that

--- a/wave/wave.go
+++ b/wave/wave.go
@@ -2,6 +2,10 @@
 // Wave (.wav) files.
 package wave
 
+import (
+	"fmt"
+)
+
 // References
 //   - https://wavefilegem.com/how_wave_files_work.html
 //   - http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
@@ -23,6 +27,19 @@ const (
 // IsValid returns true if 'f' represents a valid FormatCode
 func (f FormatCode) IsValid() bool {
 	return f == FormatCodePCM || f == FormatCodeIEEEFloat || f == FormatCodeExtensible
+}
+
+func (f FormatCode) String() string {
+	switch f {
+	case FormatCodePCM:
+		return "PCM"
+	case FormatCodeIEEEFloat:
+		return "IEEE Float"
+	case FormatCodeExtensible:
+		return "Extensible"
+	default:
+		return fmt.Sprintf("FormatCode(%d)", f)
+	}
 }
 
 // ------------------------------------------------------------------------- //
@@ -72,5 +89,24 @@ func (s SampleType) EffectiveFormatCode() FormatCode {
 		return FormatCodeIEEEFloat
 	default:
 		return FormatCodePCM
+	}
+}
+
+func (s SampleType) String() string {
+	switch s {
+	case SampleTypeUint8:
+		return "Uint8"
+	case SampleTypeInt16:
+		return "Int16"
+	case SampleTypeInt24:
+		return "Int24"
+	case SampleTypeInt32:
+		return "Int32"
+	case SampleTypeFloat32:
+		return "Float32"
+	case SampleTypeFloat64:
+		return "Float64"
+	default:
+		return fmt.Sprintf("SampleType(%d)", s)
 	}
 }

--- a/wave/wave.go
+++ b/wave/wave.go
@@ -9,6 +9,7 @@ import (
 // References
 //   - https://wavefilegem.com/how_wave_files_work.html
 //   - http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
+//   - https://www.recordingblogs.com/wiki/wave-file-format
 
 // ------------------------------------------------------------------------- //
 // FormatCode

--- a/wave/wave.go
+++ b/wave/wave.go
@@ -11,7 +11,7 @@ package wave
 // ------------------------------------------------------------------------- //
 
 // FormatCode is an enum defined by the Wave specification that dictates how
-// audio samples are to be interpreted.
+// the audio data in a wave file is to be interpreted.
 type FormatCode uint16
 
 const (
@@ -20,12 +20,17 @@ const (
 	FormatCodeExtensible FormatCode = 0xFFFE
 )
 
+// IsValid returns true if 'f' represents a valid FormatCode
+func (f FormatCode) IsValid() bool {
+	return f == FormatCodePCM || f == FormatCodeIEEEFloat || f == FormatCodeExtensible
+}
+
 // ------------------------------------------------------------------------- //
 // SampleType
 // ------------------------------------------------------------------------- //
 
 // SampleType represents the type of audio data that can be accepted by a
-// particular Writer.
+// particular Writer or the type of data that can be extracted from a Reader.
 type SampleType int
 
 const (

--- a/wave/writer.go
+++ b/wave/writer.go
@@ -391,7 +391,7 @@ func (w *Writer) getRootChunk() Chunk {
 	subChunks = append(subChunks, NewDataChunkHeader(w.dataBytes))
 
 	return NewRIFFChunk(&RIFFChunkData{
-		subChunks: subChunks,
+		SubChunks: subChunks,
 	})
 }
 

--- a/wave/writer.go
+++ b/wave/writer.go
@@ -61,16 +61,18 @@ type Writer struct {
 //     be used. Note that it is the caller's responsibility to ensure data is
 //     in the correct format, though the quantizers/dequantizers in the core
 //     package can help with that process.
-//   - sampleRate - The sample rate is measured in samples per second. Common
+//   - frameRate - The frame rate is measured in frames per second. Common
 //     values are 44100 Hz (normal for CD audio) and 48000 Hz (common for
-//     movies).
+//     cinema). Note that the term "sample rate" is more common, but isn't as
+//     well-defined in terms of multi-channel data. We use "frame rate" to be
+//     more precise about what is expected of the caller.
 //
 // WriterOptions can be used to provide additional optional inputs (e.g.
 // setting the number of channels).
 func NewWriter(
 	baseWriter io.WriteSeeker,
 	sampleType SampleType,
-	sampleRate uint32,
+	frameRate uint32,
 	opts ...WriterOption,
 ) (*Writer, error) {
 
@@ -92,7 +94,7 @@ func NewWriter(
 
 	// The user-provided fields will determine the format chunk fields
 	formatChunkData := NewFormatChunkData(
-		options.channelCount, sampleRate, sampleType,
+		options.channelCount, frameRate, sampleType,
 	)
 
 	// It's generally agreed that regular PCM data doesn't require a 'fact'
@@ -114,7 +116,7 @@ func NewWriter(
 }
 
 // WriteUint8 is used to add uint8 audio samples. Audio data is assumed to be
-// organized into samples consisting of multiple blocks, one block per channel.
+// organized into frames consisting of multiple samples, one sample per channel.
 // WriteUint8 will fail if the SampleType of the Writer is not set to
 // SampleTypeUint8.
 func (w *Writer) WriteUint8(data []uint8) error {
@@ -132,7 +134,7 @@ func (w *Writer) WriteUint8(data []uint8) error {
 }
 
 // WriteInt16 is used to add uint8 audio samples. Audio data is assumed to be
-// organized into samples consisting of multiple blocks, one block per channel.
+// organized into frames consisting of multiple samples, one sample per channel.
 // WriteInt16 will fail if the SampleType of the Writer is not set to
 // SampleTypeInt16.
 func (w *Writer) WriteInt16(data []int16) error {
@@ -151,7 +153,7 @@ func (w *Writer) WriteInt16(data []int16) error {
 }
 
 // WriteInt24 is used to add uint8 audio samples. Audio data is assumed to be
-// organized into samples consisting of multiple blocks, one block per channel.
+// organized into frames consisting of multiple samples, one sample per channel.
 // WriteInt24 will fail if the SampleType of the Writer is not set to
 // SampleTypeInt24.
 //
@@ -178,7 +180,7 @@ func (w *Writer) WriteInt24(data []int32) error {
 }
 
 // WriteInt32 is used to add uint8 audio samples. Audio data is assumed to be
-// organized into samples consisting of multiple blocks, one block per channel.
+// organized into frames consisting of multiple samples, one sample per channel.
 // WriteInt32 will fail if the SampleType of the Writer is not set to
 // SampleTypeInt32.
 func (w *Writer) WriteInt32(data []int32) error {
@@ -197,7 +199,7 @@ func (w *Writer) WriteInt32(data []int32) error {
 }
 
 // WriteFloat32 is used to add uint8 audio samples. Audio data is assumed to be
-// organized into samples consisting of multiple blocks, one block per channel.
+// organized into frames consisting of multiple samples, one sample per channel.
 // WriteFloat32 will fail if the SampleType of the Writer is not set to
 // SampleTypeFloat32.
 func (w *Writer) WriteFloat32(data []float32) error {
@@ -216,7 +218,7 @@ func (w *Writer) WriteFloat32(data []float32) error {
 }
 
 // WriteFloat64 is used to add uint8 audio samples. Audio data is assumed to be
-// organized into samples consisting of multiple blocks, one block per channel.
+// organized into frames consisting of multiple samples, one sample per channel.
 // WriteFloat64 will fail if the SampleType of the Writer is not set to
 // SampleTypeFloat64.
 func (w *Writer) WriteFloat64(data []float64) error {
@@ -257,8 +259,7 @@ func (w *Writer) write(data any) error {
 	return nil
 }
 
-// writeInt24 is a specialization of write to be used
-// int24 data.
+// writeInt24 is a specialization of write to be used with int24 data.
 func (w *Writer) writeInt24(data []int32) error {
 	if w.dataBytes == 0 {
 		err := w.writePreamble()
@@ -409,9 +410,8 @@ type WriterOption func(*writerOptions) error
 // NewWriter. A channel count of 1 will be assumed as the default unless
 // explicitly overwritten by the user.
 //
-// Note that all WriteXXX APIs assume that samples are contiguous,
-// so all blocks for a given sample should be placed next to one other in
-// memory.
+// Note that all WriteXXX APIs assume that frames are contiguous, so all
+// samples for a given frame should be placed next to one other in memory.
 func WithChannelCount(channelCount uint16) WriterOption {
 	return func(opts *writerOptions) error {
 		opts.channelCount = channelCount

--- a/wave/writer.go
+++ b/wave/writer.go
@@ -361,10 +361,7 @@ func (w *Writer) writePreamble() error {
 
 	// The preamble is represented by a hierarchy of chunks. The root chunk
 	// describes (recursively) the entire file structure.
-	preambleBytes := w.getRootChunk().Serialize()
-
-	// Write the preamble to the writer
-	_, err = w.baseWriter.Write(preambleBytes)
+	_, err = w.getRootChunk().WriteTo(w.baseWriter)
 	if err != nil {
 		return err
 	}

--- a/wave/writer_test.go
+++ b/wave/writer_test.go
@@ -21,7 +21,7 @@ func TestNewWriter_Normal(t *testing.T) {
 	// Verify that 'w' was initialized correctly
 	require.Equal(t, baseWriter, w.baseWriter)
 	require.Equal(t, SampleTypeUint8, w.sampleType)
-	require.Equal(t, uint32(44100), w.formatChunkData.SampleRate)
+	require.Equal(t, uint32(44100), w.formatChunkData.FrameRate)
 	require.Equal(t, uint16(1), w.formatChunkData.ChannelCount)
 	require.Nil(t, w.factChunkData)
 	require.Equal(t, uint32(0), w.dataBytes)
@@ -37,7 +37,7 @@ func TestNewWriter_WithFactChunk(t *testing.T) {
 	// Verify that 'w' was initialized correctly
 	require.Equal(t, baseWriter, w.baseWriter)
 	require.Equal(t, SampleTypeFloat32, w.sampleType)
-	require.Equal(t, uint32(44100), w.formatChunkData.SampleRate)
+	require.Equal(t, uint32(44100), w.formatChunkData.FrameRate)
 	require.Equal(t, uint16(1), w.formatChunkData.ChannelCount)
 	require.NotNil(t, w.factChunkData)
 	require.Equal(t, uint32(0), w.factChunkData.SampleFrames)


### PR DESCRIPTION
**Changelog**:
  - Added initial implementation for `wave.Reader` that allows for bulk / streaming reading of wave files.
  - Added support for Go 1.21
  - Added additional examples to show how to use the reader API
  - Updated documentation
  - Several additional test cases. (Coverage is still quite low for the reader API. Improving that is a TODO.)